### PR TITLE
sharpen the ROI image

### DIFF
--- a/twitch-nonogram-canvas.user.js
+++ b/twitch-nonogram-canvas.user.js
@@ -345,6 +345,54 @@
         }
     }
 
+    function sharpen(ctx, w, h, mix) {
+        var x, sx, sy, r, g, b, a, dstOff, srcOff, wt, cx, cy, scy, scx,
+            weights = [0, -1, 0, -1, 5, -1, 0, -1, 0],
+            katet = Math.round(Math.sqrt(weights.length)),
+            half = (katet * 0.5) | 0,
+            dstData = ctx.createImageData(w, h),
+            dstBuff = dstData.data,
+            srcBuff = ctx.getImageData(0, 0, w, h).data,
+            y = h;
+
+        while (y--) {
+            x = w;
+            while (x--) {
+                sy = y;
+                sx = x;
+                dstOff = (y * w + x) * 4;
+                r = 0;
+                g = 0;
+                b = 0;
+                a = 0;
+
+                for (cy = 0; cy < katet; cy++) {
+                    for (cx = 0; cx < katet; cx++) {
+                        scy = sy + cy - half;
+                        scx = sx + cx - half;
+
+                        if (scy >= 0 && scy < h && scx >= 0 && scx < w) {
+                            srcOff = (scy * w + scx) * 4;
+                            wt = weights[cy * katet + cx];
+
+                            r += srcBuff[srcOff] * wt;
+                            g += srcBuff[srcOff + 1] * wt;
+                            b += srcBuff[srcOff + 2] * wt;
+                            a += srcBuff[srcOff + 3] * wt;
+                        }
+                    }
+                }
+
+                dstBuff[dstOff] = r * mix + srcBuff[dstOff] * (1 - mix);
+                dstBuff[dstOff + 1] = g * mix + srcBuff[dstOff + 1] * (1 - mix);
+                dstBuff[dstOff + 2] = b * mix + srcBuff[dstOff + 2] * (1 - mix);
+                dstBuff[dstOff + 3] = srcBuff[dstOff + 3];
+            }
+        }
+
+        ctx.putImageData(dstData, 0, 0);
+    }
+
     function drawROI() {
         const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
         if (!video) return;
@@ -361,6 +409,7 @@
             roiX, roiY, roiWidth, roiHeight,
             0, 0, canvas.width, canvas.height
         );
+	sharpen(ctx, canvas.width, canvas.height, 0.9);
     }
 
     function updateCanvasSize() {


### PR DESCRIPTION
I found this sharpen function here: https://gist.github.com/mikecao/65d9fc92dc7197cb8a7c
It makes the bigger magnified nonograms better readable with the lower video quality.