### PR TITLE
Split userscript into grouped ES modules and add Rollup build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.opencode/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,32 @@ A draggable nonogram puzzle overlay for Twitch streams, complete with canvas ren
 🛠 Installation
 Install Tampermonkey in your browser.
 
-Add a new userscript and paste in the code.
+Build the userscript if you are working from source:
+
+```bash
+npm install
+npm run build
+```
+
+The generated userscript is written to:
+
+- `twitch-nonogram-canvas.user.js`
+
+`twitch-nonogram-canvas.user.js` is generated from the files in `src/`. Edit the source modules and rebuild instead of editing the generated userscript directly.
+
+Add a new userscript and paste in the code, or install the generated `.user.js` file directly.
 
 Visit gokiccoon Twitch stream.
+
+🧪 Development
+
+Rebuild automatically while working on the source modules:
+
+```bash
+npm run build:watch
+```
+
+This watches the `src/` files and updates `twitch-nonogram-canvas.user.js` on changes.
 
 🧾 How to Use
 🔲 Grid Interaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,653 @@
+{
+  "name": "nonogram-twitch-overlay",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nonogram-twitch-overlay",
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "rollup": "^4.52.5"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nonogram-twitch-overlay",
+  "private": true,
+  "scripts": {
+    "build": "rollup -c",
+    "build:watch": "rollup -c -w"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "rollup": "^4.52.5"
+  }
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,0 +1,16 @@
+// Rollup bundles the ES modules into the single installable userscript file.
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { readFileSync } from 'node:fs';
+
+const banner = readFileSync(new URL('./src/userscript/banner.js', import.meta.url), 'utf8').trim();
+
+export default {
+  input: 'src/userscript/main.js',
+  output: {
+    file: 'twitch-nonogram-canvas.user.js',
+    format: 'iife',
+    banner,
+    sourcemap: false
+  },
+  plugins: [nodeResolve()]
+};

--- a/src/app.js
+++ b/src/app.js
@@ -2,15 +2,28 @@
 import { configureNonogramGrid, createGrid, initCells } from './nonogram-grid.js';
 import { createMainButtons, render, setupCanvas, updateCanvasSize, minimizeCanvas } from './overlay-ui.js';
 import { createConfigPanel, createControlAndStatus, createExtraConfigPanel, configureStatusControls } from './status-controls.js';
-import { state, clearRenderHandle } from './state.js';
+import { state, clearRenderHandle, initState } from './state.js';
 import { ensureProgressLoop } from './twitch-chat.js';
 import { scheduleAutoRedeem } from './twitch-redeem.js';
 import { updateROI } from './overlay-ui.js';
 
-configureNonogramGrid({ updateCanvasSize });
-configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+const readyCallbacks = [];
+const shutdownCallbacks = [];
+let hasBootstrapped = false;
+
+function notifyCallbacks(callbacks) {
+  callbacks.forEach(callback => {
+    try {
+      callback();
+    } catch (error) {
+      console.error('Lifecycle callback failed:', error);
+    }
+  });
+}
 
 function cleanup() {
+  notifyCallbacks(shutdownCallbacks);
+
   if (state.redeemButtonMonitorId) clearInterval(state.redeemButtonMonitorId);
   if (state.activityBtnMonitorId) clearInterval(state.activityBtnMonitorId);
   if (state.progressTimer) clearInterval(state.progressTimer);
@@ -25,9 +38,25 @@ function cleanup() {
   if (state.documentMouseUpHandler) {
     document.removeEventListener('mouseup', state.documentMouseUpHandler);
   }
+
+  state.redeemButtonMonitorId = null;
+  state.activityBtnMonitorId = null;
+  state.progressTimer = null;
+  state.sendLoopTimer = null;
+  state.autoRedeemTimer = null;
+  state.roiInterval = null;
+  state.documentMouseMoveHandler = null;
+  state.documentMouseUpHandler = null;
 }
 
 function onLoad() {
+  if (hasBootstrapped) return;
+  hasBootstrapped = true;
+
+  initState();
+  configureNonogramGrid({ updateCanvasSize });
+  configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+
   setupCanvas();
   initCells();
   updateCanvasSize();
@@ -42,9 +71,23 @@ function onLoad() {
   render();
   state.roiInterval = setInterval(updateROI, 1000);
   scheduleAutoRedeem();
+  notifyCallbacks(readyCallbacks);
+}
+
+export function onReady(callback) {
+  readyCallbacks.push(callback);
+}
+
+export function onShutdown(callback) {
+  shutdownCallbacks.push(callback);
 }
 
 export function bootstrap() {
   window.addEventListener('beforeunload', cleanup);
-  window.addEventListener('load', onLoad);
+  if (document.readyState === 'complete') {
+    onLoad();
+    return;
+  }
+
+  window.addEventListener('load', onLoad, { once: true });
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,9 @@
 // Bootstraps the userscript, wires the grouped modules together, and handles cleanup.
 import { configureNonogramGrid, createGrid, initCells } from './nonogram-grid.js';
-import { createMainButtons, render, setupCanvas, updateCanvasSize, minimizeCanvas } from './overlay-ui.js';
-import { createConfigPanel, createControlAndStatus, createExtraConfigPanel, configureStatusControls } from './status-controls.js';
+import { createMainButtons, render, setupCanvas, updateCanvasSize, minimizeCanvas, updateROI } from './overlay-ui.js';
+import { createControlAndStatus, createExtraConfigPanel, configureStatusControls } from './status-controls.js';
 import { state, clearRenderHandle, initState } from './state.js';
 import { ensureProgressLoop } from './twitch-chat.js';
-import { scheduleAutoRedeem } from './twitch-redeem.js';
-import { updateROI } from './overlay-ui.js';
 
 const readyCallbacks = [];
 const shutdownCallbacks = [];
@@ -24,11 +22,9 @@ function notifyCallbacks(callbacks) {
 function cleanup() {
   notifyCallbacks(shutdownCallbacks);
 
-  if (state.redeemButtonMonitorId) clearInterval(state.redeemButtonMonitorId);
   if (state.activityBtnMonitorId) clearInterval(state.activityBtnMonitorId);
   if (state.progressTimer) clearInterval(state.progressTimer);
   if (state.sendLoopTimer) clearInterval(state.sendLoopTimer);
-  if (state.autoRedeemTimer) clearTimeout(state.autoRedeemTimer);
   if (state.roiInterval) clearInterval(state.roiInterval);
   clearRenderHandle();
 
@@ -39,11 +35,9 @@ function cleanup() {
     document.removeEventListener('mouseup', state.documentMouseUpHandler);
   }
 
-  state.redeemButtonMonitorId = null;
   state.activityBtnMonitorId = null;
   state.progressTimer = null;
   state.sendLoopTimer = null;
-  state.autoRedeemTimer = null;
   state.roiInterval = null;
   state.documentMouseMoveHandler = null;
   state.documentMouseUpHandler = null;
@@ -61,7 +55,6 @@ function onLoad() {
   initCells();
   updateCanvasSize();
   createMainButtons();
-  createConfigPanel();
   createControlAndStatus();
   createExtraConfigPanel();
   if (state.autosendEnabled) {
@@ -70,7 +63,6 @@ function onLoad() {
   }
   render();
   state.roiInterval = setInterval(updateROI, 1000);
-  scheduleAutoRedeem();
   notifyCallbacks(readyCallbacks);
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,50 @@
+// Bootstraps the userscript, wires the grouped modules together, and handles cleanup.
+import { configureNonogramGrid, createGrid, initCells } from './nonogram-grid.js';
+import { createMainButtons, render, setupCanvas, updateCanvasSize, minimizeCanvas } from './overlay-ui.js';
+import { createConfigPanel, createControlAndStatus, createExtraConfigPanel, configureStatusControls } from './status-controls.js';
+import { state, clearRenderHandle } from './state.js';
+import { ensureProgressLoop } from './twitch-chat.js';
+import { scheduleAutoRedeem } from './twitch-redeem.js';
+import { updateROI } from './overlay-ui.js';
+
+configureNonogramGrid({ updateCanvasSize });
+configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+
+function cleanup() {
+  if (state.redeemButtonMonitorId) clearInterval(state.redeemButtonMonitorId);
+  if (state.activityBtnMonitorId) clearInterval(state.activityBtnMonitorId);
+  if (state.progressTimer) clearInterval(state.progressTimer);
+  if (state.sendLoopTimer) clearInterval(state.sendLoopTimer);
+  if (state.autoRedeemTimer) clearTimeout(state.autoRedeemTimer);
+  if (state.roiInterval) clearInterval(state.roiInterval);
+  clearRenderHandle();
+
+  if (state.documentMouseMoveHandler) {
+    document.removeEventListener('mousemove', state.documentMouseMoveHandler);
+  }
+  if (state.documentMouseUpHandler) {
+    document.removeEventListener('mouseup', state.documentMouseUpHandler);
+  }
+}
+
+function onLoad() {
+  setupCanvas();
+  initCells();
+  updateCanvasSize();
+  createMainButtons();
+  createConfigPanel();
+  createControlAndStatus();
+  createExtraConfigPanel();
+  if (state.autosendEnabled) {
+    state.nextSendAt = Date.now();
+    ensureProgressLoop();
+  }
+  render();
+  state.roiInterval = setInterval(updateROI, 1000);
+  scheduleAutoRedeem();
+}
+
+export function bootstrap() {
+  window.addEventListener('beforeunload', cleanup);
+  window.addEventListener('load', onLoad);
+}

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import { createMainButtons, render, setupCanvas, updateCanvasSize, minimizeCanva
 import { createControlAndStatus, createExtraConfigPanel, configureStatusControls } from './status-controls.js';
 import { state, clearRenderHandle, initState } from './state.js';
 import { ensureProgressLoop } from './twitch-chat.js';
+import { cancelAutoRedeem } from './twitch-redeem.js';
 
 const readyCallbacks = [];
 const shutdownCallbacks = [];
@@ -26,6 +27,7 @@ function cleanup() {
   if (state.progressTimer) clearInterval(state.progressTimer);
   if (state.sendLoopTimer) clearInterval(state.sendLoopTimer);
   if (state.roiInterval) clearInterval(state.roiInterval);
+  cancelAutoRedeem();
   clearRenderHandle();
 
   if (state.documentMouseMoveHandler) {
@@ -39,6 +41,7 @@ function cleanup() {
   state.progressTimer = null;
   state.sendLoopTimer = null;
   state.roiInterval = null;
+  state.buttonContainer = null;
   state.documentMouseMoveHandler = null;
   state.documentMouseUpHandler = null;
 }

--- a/src/nonogram-grid.js
+++ b/src/nonogram-grid.js
@@ -5,14 +5,33 @@ import { guardedExport } from './twitch-redeem.js';
 
 let updateCanvasSizeRef;
 
+const COL_LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+const CELL_EMPTY = 0;
+const CELL_FILLED = 1;
+const CELL_MARKED = 2;
+
+function colLetter(index) {
+  return COL_LETTERS[index];
+}
+
+function safeClipboardWrite(text) {
+  try {
+    navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.warn('Clipboard write failed:', error);
+    alert(text);
+  }
+}
+
 export function configureNonogramGrid({ updateCanvasSize }) {
   updateCanvasSizeRef = updateCanvasSize;
 }
 
 export function initCells() {
-  state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(0));
+  state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(CELL_EMPTY));
   state.lastExported = new Set();
   state.lastExportedWhite = new Set();
+  state.geometryCache = null;
   resetClueDashes();
 }
 
@@ -22,20 +41,17 @@ function clamp(v, min, max) {
 
 export async function exportDartCommand() {
   let msg = '!darts';
-  for (let i = 0; i < msg.length; i++) {
-    if (i === state.lastDartExportIndex) {
-      msg = msg.substring(0, i) + msg[i].toUpperCase() + msg.substring(i + 1);
-      state.lastDartExportIndex++;
-      if (state.lastDartExportIndex >= msg.length) {
-        state.lastDartExportIndex = 1;
-      }
-      break;
-    }
+  const chars = [...msg];
+  chars[state.lastDartExportIndex] = chars[state.lastDartExportIndex].toUpperCase();
+  msg = chars.join('');
+  state.lastDartExportIndex++;
+  if (state.lastDartExportIndex >= msg.length) {
+    state.lastDartExportIndex = 1;
   }
   if (state.autosendEnabled) {
     scheduleSend(msg);
   } else {
-    navigator.clipboard.writeText(msg);
+    safeClipboardWrite(msg);
   }
 }
 
@@ -82,8 +98,22 @@ function removeNearestRowDash(row, canvasX, threshold = 10) {
 }
 
 export function computeGridGeometry() {
+  const cacheKey = [
+    state.size,
+    state.colClueCount,
+    state.fineTune,
+    state.anchorX,
+    state.anchorY,
+    state.canvas?.width,
+    state.canvas?.height
+  ].join(':');
+
+  if (state.geometryCache?.key === cacheKey) {
+    return state.geometryCache.value;
+  }
+
   state.ctx.font = 'bold 30px Arial';
-  const clueW = state.ctx.measureText('0'.repeat(state.rowClueCount)).width;
+  const clueW = state.ctx.measureText('0').width;
   const clueH = 30 * state.colClueCount + 5;
 
   const layout = getLayoutSettings(state.size, state.colClueCount);
@@ -99,7 +129,9 @@ export function computeGridGeometry() {
   const ox = state.canvas.width - cellSize * state.size - state.anchorX;
   const oy = state.canvas.height - cellSize * state.size - state.anchorY;
 
-  return { clueW, clueH, cellSize, ox, oy };
+  const geometry = { clueW, clueH, cellSize, ox, oy };
+  state.geometryCache = { key: cacheKey, value: geometry };
+  return geometry;
 }
 
 function resetClueDashes() {
@@ -119,23 +151,23 @@ function exportCellsInner() {
   const coords = [];
   state.cellStates.forEach((row, r) => {
     row.forEach((s, c) => {
-      if (s === 1) {
-        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-        if (!state.lastExported.has(coord)) {
-          coords.push(coord);
-          state.lastExported.add(coord);
+        if (s === 1) {
+          const coord = `${colLetter(c)}${r + 1}`;
+          if (!state.lastExported.has(coord)) {
+            coords.push(coord);
+            state.lastExported.add(coord);
         }
       }
     });
   });
-  if (coords.length) {
-    const msg = `!fill ${coords.join(' ')}`;
-    if (state.autosendEnabled) {
-      scheduleSend(msg);
-    } else {
-      navigator.clipboard.writeText(msg);
+    if (coords.length) {
+      const msg = `!fill ${coords.join(' ')}`;
+      if (state.autosendEnabled) {
+        scheduleSend(msg);
+      } else {
+        safeClipboardWrite(msg);
+      }
     }
-  }
 }
 
 function exportAllCellsInner(mode) {
@@ -149,7 +181,7 @@ function exportAllCellsInner(mode) {
     state.cellStates.forEach((row, r) => {
       row.forEach((s, c) => {
         if (s === 1) {
-          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          const coord = `${colLetter(c)}${r + 1}`;
           coords.push(coord);
           state.lastExported.add(coord);
         }
@@ -157,14 +189,14 @@ function exportAllCellsInner(mode) {
     });
     if (coords.length) {
       const msg = `!fill ${coords.join(' ')}`;
-      navigator.clipboard.writeText(msg);
       if (state.autosendEnabled) scheduleSend(msg);
+      else safeClipboardWrite(msg);
     }
   } else if (mode === 'white') {
     state.cellStates.forEach((row, r) => {
       row.forEach((s, c) => {
-        if (s === 2) {
-          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+        if (s === CELL_MARKED) {
+          const coord = `${colLetter(c)}${r + 1}`;
           coords.push(coord);
           state.lastExportedWhite.add(coord);
         }
@@ -172,8 +204,8 @@ function exportAllCellsInner(mode) {
     });
     if (coords.length) {
       const msg = `!empty ${coords.join(' ')}`;
-      navigator.clipboard.writeText(msg);
       if (state.autosendEnabled) scheduleSend(msg);
+      else safeClipboardWrite(msg);
     }
   }
 }
@@ -183,7 +215,7 @@ function exportWhiteCellsInner() {
   state.cellStates.forEach((row, r) => {
     row.forEach((s, c) => {
       if (s === 2) {
-        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+        const coord = `${colLetter(c)}${r + 1}`;
         if (!state.lastExportedWhite.has(coord)) {
           coords.push(coord);
           state.lastExportedWhite.add(coord);
@@ -196,7 +228,7 @@ function exportWhiteCellsInner() {
     if (state.autosendEnabled) {
       scheduleSend(msg);
     } else {
-      navigator.clipboard.writeText(msg);
+      safeClipboardWrite(msg);
     }
   }
 }
@@ -214,19 +246,13 @@ export function exportWhiteCells() {
 }
 
 export function exportClearCommand() {
-  const letters = 'abcdefghijklmnopqrstuvwxyz';
   const ranges = [];
   for (let c = 0; c < state.size; c++) {
-    const col = letters[c];
+    const col = colLetter(c);
     ranges.push(`${col}1-${col}${state.size}`);
   }
   const clearCmd = `!clear ${ranges.join(',')}`;
-  try {
-    navigator.clipboard.writeText(clearCmd);
-  } catch (e) {
-    console.warn('Clipboard write failed:', e);
-    alert(clearCmd);
-  }
+  safeClipboardWrite(clearCmd);
 }
 
 export function createGrid() {
@@ -281,21 +307,24 @@ export function createGrid() {
     }
   }
 
+  const filledColor = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
+  const markedColor = 'rgba(255, 255, 255, 0.6)';
+
   for (let r = 0; r < state.size; r++) {
     for (let c = 0; c < state.size; c++) {
       const x = ox + c * cellSize;
       const y = oy + r * cellSize;
 
-      if (state.cellStates[r][c] === 1) {
-        state.ctx.fillStyle = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
-      } else if (state.cellStates[r][c] === 2) {
-        state.ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+      if (state.cellStates[r][c] === CELL_FILLED) {
+        state.ctx.fillStyle = filledColor;
+      } else if (state.cellStates[r][c] === CELL_MARKED) {
+        state.ctx.fillStyle = markedColor;
       }
 
       state.ctx.strokeRect(x, y, cellSize, cellSize);
-      if (state.cellStates[r][c] === 1 || state.cellStates[r][c] === 2) {
+      if (state.cellStates[r][c] === CELL_FILLED || state.cellStates[r][c] === CELL_MARKED) {
         state.ctx.fillRect(x, y, cellSize, cellSize);
-        if (state.cellStates[r][c] === 2) state.ctx.fillStyle = 'black';
+        if (state.cellStates[r][c] === CELL_MARKED) state.ctx.fillStyle = 'black';
       }
     }
   }
@@ -341,11 +370,11 @@ export function onCanvasMouseDown(e) {
 
   if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
     state.isMarking = true;
-    state.markValue = e.button === 0 ? 1 : 2;
+    state.markValue = e.button === 0 ? CELL_FILLED : CELL_MARKED;
     state.eraseMode = state.cellStates[r][c] === state.markValue;
 
     const prevValue = state.cellStates[r][c];
-    const newValue = state.eraseMode ? 0 : state.markValue;
+    const newValue = state.eraseMode ? CELL_EMPTY : state.markValue;
     state.cellStates[r][c] = newValue;
     state.currentAction = [{ row: r, col: c, previous: prevValue, newValue }];
     createGrid();
@@ -387,11 +416,13 @@ export function onCanvasMouseMove(e) {
     newCol = c;
   }
 
+  const hoverChanged = newRow !== state.hoveredRow || newCol !== state.hoveredCol;
   state.hoveredRow = newRow;
   state.hoveredCol = newCol;
 
+  let cellChanged = false;
   if (state.isMarking && newRow >= 0 && newCol >= 0) {
-    const targetValue = state.eraseMode ? 0 : state.markValue;
+    const targetValue = state.eraseMode ? CELL_EMPTY : state.markValue;
     if (state.cellStates[newRow][newCol] !== targetValue) {
       if (!state.currentAction) state.currentAction = [];
       state.currentAction.push({
@@ -401,19 +432,22 @@ export function onCanvasMouseMove(e) {
         newValue: targetValue
       });
       state.cellStates[newRow][newCol] = targetValue;
+      cellChanged = true;
     }
   }
 
-  createGrid();
+  if (hoverChanged || cellChanged) {
+    createGrid();
+  }
 }
 
 export function undoLastAction() {
   if (!state.moveHistory.length) return;
   const lastAction = state.moveHistory.pop();
   lastAction.forEach(({ row, col, previous, newValue }) => {
-    const coord = `${String.fromCharCode(97 + col)}${row + 1}`;
-    if (newValue === 1) state.lastExported.delete(coord);
-    if (newValue === 2) state.lastExportedWhite.delete(coord);
+    const coord = `${colLetter(col)}${row + 1}`;
+    if (newValue === CELL_FILLED) state.lastExported.delete(coord);
+    if (newValue === CELL_MARKED) state.lastExportedWhite.delete(coord);
     state.cellStates[row][col] = previous;
   });
   createGrid();
@@ -449,12 +483,14 @@ export function incrementCols() {
 
 export function decrementFineTune() {
   state.fineTune--;
+  state.geometryCache = null;
   saveLayout();
   updateCanvasSizeRef();
 }
 
 export function incrementFineTune() {
   state.fineTune++;
+  state.geometryCache = null;
   saveLayout();
   updateCanvasSizeRef();
 }
@@ -462,7 +498,6 @@ export function incrementFineTune() {
 export function resetSizeDefaults() {
   saveLayout();
   state.size = 4;
-  state.rowClueCount = 1;
   state.colClueCount = 1;
   initCells();
   updateCanvasSizeRef();

--- a/src/nonogram-grid.js
+++ b/src/nonogram-grid.js
@@ -1,0 +1,469 @@
+// Owns nonogram state, geometry, drawing, exports, and canvas interaction logic.
+import { getLayoutSettings, loadLayout, saveLayout, state } from './state.js';
+import { scheduleSend } from './twitch-chat.js';
+import { guardedExport } from './twitch-redeem.js';
+
+let updateCanvasSizeRef;
+
+export function configureNonogramGrid({ updateCanvasSize }) {
+  updateCanvasSizeRef = updateCanvasSize;
+}
+
+export function initCells() {
+  state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(0));
+  state.lastExported = new Set();
+  state.lastExportedWhite = new Set();
+  resetClueDashes();
+}
+
+function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+export async function exportDartCommand() {
+  let msg = '!darts';
+  for (let i = 0; i < msg.length; i++) {
+    if (i === state.lastDartExportIndex) {
+      msg = msg.substring(0, i) + msg[i].toUpperCase() + msg.substring(i + 1);
+      state.lastDartExportIndex++;
+      if (state.lastDartExportIndex >= msg.length) {
+        state.lastDartExportIndex = 1;
+      }
+      break;
+    }
+  }
+  if (state.autosendEnabled) {
+    scheduleSend(msg);
+  } else {
+    navigator.clipboard.writeText(msg);
+  }
+}
+
+function addColDash(col, pos, clueH) {
+  if (col < 0 || col >= state.size) return;
+  if (!Array.isArray(state.colDashes[col])) state.colDashes[col] = [];
+  state.colDashes[col].push(clamp(pos, 0, clueH));
+}
+
+function removeNearestColDash(col, pos, threshold = 10) {
+  const arr = state.colDashes[col];
+  if (!arr || !arr.length) return;
+  let best = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < arr.length; i++) {
+    const d = Math.abs(arr[i] - pos);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
+}
+
+function addRowDash(row, canvasX) {
+  if (row < 0 || row >= state.size) return;
+  if (!Array.isArray(state.rowDashes[row])) state.rowDashes[row] = [];
+  state.rowDashes[row].push(canvasX);
+}
+
+function removeNearestRowDash(row, canvasX, threshold = 10) {
+  const arr = state.rowDashes[row];
+  if (!arr || !arr.length) return;
+  let best = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < arr.length; i++) {
+    const d = Math.abs(arr[i] - canvasX);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
+}
+
+export function computeGridGeometry() {
+  state.ctx.font = 'bold 30px Arial';
+  const clueW = state.ctx.measureText('0'.repeat(state.rowClueCount)).width;
+  const clueH = 30 * state.colClueCount + 5;
+
+  const layout = getLayoutSettings(state.size, state.colClueCount);
+  let cellSize;
+  if (layout) {
+    const defaultCellSize = layout.cellSize;
+    cellSize = (defaultCellSize * state.size + state.fineTune) / state.size;
+  } else {
+    const gridSize = Math.min(state.canvas.width - clueW, state.canvas.height - clueH);
+    cellSize = (gridSize + state.fineTune) / state.size;
+  }
+
+  const ox = state.canvas.width - cellSize * state.size - state.anchorX;
+  const oy = state.canvas.height - cellSize * state.size - state.anchorY;
+
+  return { clueW, clueH, cellSize, ox, oy };
+}
+
+function resetClueDashes() {
+  state.rowDashes = Array.from({ length: state.size }, () => []);
+  state.colDashes = Array.from({ length: state.size }, () => []);
+}
+
+export async function cleanAll() {
+  return guardedExport(() => {
+    initCells();
+    createGrid();
+    exportClearCommand();
+  });
+}
+
+function exportCellsInner() {
+  const coords = [];
+  state.cellStates.forEach((row, r) => {
+    row.forEach((s, c) => {
+      if (s === 1) {
+        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+        if (!state.lastExported.has(coord)) {
+          coords.push(coord);
+          state.lastExported.add(coord);
+        }
+      }
+    });
+  });
+  if (coords.length) {
+    const msg = `!fill ${coords.join(' ')}`;
+    if (state.autosendEnabled) {
+      scheduleSend(msg);
+    } else {
+      navigator.clipboard.writeText(msg);
+    }
+  }
+}
+
+function exportAllCellsInner(mode) {
+  state.lastExported.clear();
+  state.lastExportedWhite.clear();
+
+  if (!mode) return;
+
+  const coords = [];
+  if (mode === 'black') {
+    state.cellStates.forEach((row, r) => {
+      row.forEach((s, c) => {
+        if (s === 1) {
+          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          coords.push(coord);
+          state.lastExported.add(coord);
+        }
+      });
+    });
+    if (coords.length) {
+      const msg = `!fill ${coords.join(' ')}`;
+      navigator.clipboard.writeText(msg);
+      if (state.autosendEnabled) scheduleSend(msg);
+    }
+  } else if (mode === 'white') {
+    state.cellStates.forEach((row, r) => {
+      row.forEach((s, c) => {
+        if (s === 2) {
+          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          coords.push(coord);
+          state.lastExportedWhite.add(coord);
+        }
+      });
+    });
+    if (coords.length) {
+      const msg = `!empty ${coords.join(' ')}`;
+      navigator.clipboard.writeText(msg);
+      if (state.autosendEnabled) scheduleSend(msg);
+    }
+  }
+}
+
+function exportWhiteCellsInner() {
+  const coords = [];
+  state.cellStates.forEach((row, r) => {
+    row.forEach((s, c) => {
+      if (s === 2) {
+        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+        if (!state.lastExportedWhite.has(coord)) {
+          coords.push(coord);
+          state.lastExportedWhite.add(coord);
+        }
+      }
+    });
+  });
+  if (coords.length) {
+    const msg = `!empty ${coords.join(' ')}`;
+    if (state.autosendEnabled) {
+      scheduleSend(msg);
+    } else {
+      navigator.clipboard.writeText(msg);
+    }
+  }
+}
+
+export function exportCells() {
+  return guardedExport(exportCellsInner);
+}
+
+export function exportAllCells(mode) {
+  return guardedExport(exportAllCellsInner, mode);
+}
+
+export function exportWhiteCells() {
+  return guardedExport(exportWhiteCellsInner);
+}
+
+export function exportClearCommand() {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  const ranges = [];
+  for (let c = 0; c < state.size; c++) {
+    const col = letters[c];
+    ranges.push(`${col}1-${col}${state.size}`);
+  }
+  const clearCmd = `!clear ${ranges.join(',')}`;
+  try {
+    navigator.clipboard.writeText(clearCmd);
+  } catch (e) {
+    console.warn('Clipboard write failed:', e);
+    alert(clearCmd);
+  }
+}
+
+export function createGrid() {
+  const { clueH, cellSize, ox, oy } = computeGridGeometry();
+
+  state.ctx.strokeStyle = 'cyan';
+  state.ctx.lineWidth = 1;
+
+  if ((state.hoveredRow >= 0 && state.hoveredRow < state.size) || (state.hoveredCol >= 0 && state.hoveredCol < state.size)) {
+    state.ctx.fillStyle = 'rgba(100, 150, 255, 0.25)';
+
+    if (state.hoveredRow >= 0) {
+      const y = oy + state.hoveredRow * cellSize;
+      state.ctx.fillRect(ox, y, cellSize * state.size, cellSize);
+      if (ox > 0) state.ctx.fillRect(0, y, ox, cellSize);
+    }
+
+    if (state.hoveredCol >= 0) {
+      const x = ox + state.hoveredCol * cellSize;
+      state.ctx.fillRect(x, oy, cellSize, cellSize * state.size);
+      state.ctx.fillRect(x, oy - clueH, cellSize, clueH);
+    }
+  }
+
+  const dashH = 3;
+
+  {
+    const dashW = cellSize / 3;
+    state.ctx.fillStyle = '#ffeb3b';
+    for (let c = 0; c < state.size; c++) {
+      const colX = ox + c * cellSize + cellSize / 2;
+      const baseY = oy - clueH;
+      const list = state.colDashes[c] || [];
+      for (const pos of list) {
+        const y = clamp(baseY + pos - dashH / 2, baseY, oy - dashH);
+        state.ctx.fillRect(colX - dashW / 2, y, dashW, dashH);
+      }
+    }
+  }
+
+  {
+    const dashW = cellSize / 4;
+    state.ctx.fillStyle = '#ffeb3b';
+    for (let r = 0; r < state.size; r++) {
+      const rowTop = oy + r * cellSize;
+      const list = state.rowDashes[r] || [];
+      for (const canvasX of list) {
+        const xDraw = Math.max(0, Math.min(canvasX, ox));
+        const yDash = rowTop + (cellSize - dashH) / 2;
+        state.ctx.fillRect(xDraw - dashW / 2, yDash, dashW, dashH);
+      }
+    }
+  }
+
+  for (let r = 0; r < state.size; r++) {
+    for (let c = 0; c < state.size; c++) {
+      const x = ox + c * cellSize;
+      const y = oy + r * cellSize;
+
+      if (state.cellStates[r][c] === 1) {
+        state.ctx.fillStyle = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
+      } else if (state.cellStates[r][c] === 2) {
+        state.ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+      }
+
+      state.ctx.strokeRect(x, y, cellSize, cellSize);
+      if (state.cellStates[r][c] === 1 || state.cellStates[r][c] === 2) {
+        state.ctx.fillRect(x, y, cellSize, cellSize);
+        if (state.cellStates[r][c] === 2) state.ctx.fillStyle = 'black';
+      }
+    }
+  }
+}
+
+export function onCanvasMouseDown(e) {
+  e.preventDefault();
+
+  const rect = state.canvas.getBoundingClientRect();
+  const scaleX = state.canvas.width / rect.width;
+  const scaleY = state.canvas.height / rect.height;
+  const x = (e.clientX - rect.left) * scaleX;
+  const y = (e.clientY - rect.top) * scaleY;
+
+  const { clueH, cellSize, ox, oy } = computeGridGeometry();
+  const yOverGrid = y >= oy && y < oy + state.size * cellSize;
+
+  const inTopClues = x >= ox && x < ox + state.size * cellSize && y >= oy - clueH && y < oy;
+  if (inTopClues) {
+    const col = Math.floor((x - ox) / cellSize);
+    if (col >= 0 && col < state.size) {
+      const pos = y - (oy - clueH);
+      if (e.button === 0) addColDash(col, pos, clueH);
+      else if (e.button === 2) removeNearestColDash(col, pos, 10);
+      createGrid();
+      return;
+    }
+  }
+
+  const inLeftClues = x < ox && yOverGrid;
+  if (inLeftClues) {
+    const row = Math.floor((y - oy) / cellSize);
+    if (row >= 0 && row < state.size) {
+      if (e.button === 0) addRowDash(row, x);
+      else if (e.button === 2) removeNearestRowDash(row, x, 10);
+      createGrid();
+      return;
+    }
+  }
+
+  const c = Math.floor((x - ox) / cellSize);
+  const r = Math.floor((y - oy) / cellSize);
+
+  if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
+    state.isMarking = true;
+    state.markValue = e.button === 0 ? 1 : 2;
+    state.eraseMode = state.cellStates[r][c] === state.markValue;
+
+    const prevValue = state.cellStates[r][c];
+    const newValue = state.eraseMode ? 0 : state.markValue;
+    state.cellStates[r][c] = newValue;
+    state.currentAction = [{ row: r, col: c, previous: prevValue, newValue }];
+    createGrid();
+  } else {
+    state.isDragging = true;
+    state.dragOffsetX = e.clientX - state.frame.offsetLeft;
+    state.dragOffsetY = e.clientY - state.frame.offsetTop;
+  }
+}
+
+export function onCanvasMouseMove(e) {
+  const rect = state.canvas.getBoundingClientRect();
+  const scaleX = state.canvas.width / rect.width;
+  const scaleY = state.canvas.height / rect.height;
+  const x = (e.clientX - rect.left) * scaleX;
+  const y = (e.clientY - rect.top) * scaleY;
+
+  const { clueH, cellSize, ox, oy } = computeGridGeometry();
+  const c = Math.floor((x - ox) / cellSize);
+  const r = Math.floor((y - oy) / cellSize);
+
+  let newRow = -1;
+  let newCol = -1;
+
+  const yOverGrid = y >= oy && y < oy + state.size * cellSize;
+  if (yOverGrid) {
+    const ry = Math.floor((y - oy) / cellSize);
+    if (ry >= 0 && ry < state.size) newRow = ry;
+  }
+
+  const inTopClues = x >= ox && x < ox + state.size * cellSize && y >= oy - clueH && y < oy;
+  if (inTopClues) {
+    const col = Math.floor((x - ox) / cellSize);
+    if (col >= 0 && col < state.size) newCol = col;
+  }
+
+  if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
+    newRow = r;
+    newCol = c;
+  }
+
+  state.hoveredRow = newRow;
+  state.hoveredCol = newCol;
+
+  if (state.isMarking && newRow >= 0 && newCol >= 0) {
+    const targetValue = state.eraseMode ? 0 : state.markValue;
+    if (state.cellStates[newRow][newCol] !== targetValue) {
+      if (!state.currentAction) state.currentAction = [];
+      state.currentAction.push({
+        row: newRow,
+        col: newCol,
+        previous: state.cellStates[newRow][newCol],
+        newValue: targetValue
+      });
+      state.cellStates[newRow][newCol] = targetValue;
+    }
+  }
+
+  createGrid();
+}
+
+export function undoLastAction() {
+  if (!state.moveHistory.length) return;
+  const lastAction = state.moveHistory.pop();
+  lastAction.forEach(({ row, col, previous, newValue }) => {
+    const coord = `${String.fromCharCode(97 + col)}${row + 1}`;
+    if (newValue === 1) state.lastExported.delete(coord);
+    if (newValue === 2) state.lastExportedWhite.delete(coord);
+    state.cellStates[row][col] = previous;
+  });
+  createGrid();
+}
+
+export function decrementSize() {
+  state.size = Math.max(1, state.size - 1);
+  loadLayout();
+  initCells();
+  updateCanvasSizeRef();
+}
+
+export function incrementSize() {
+  state.size++;
+  loadLayout();
+  initCells();
+  updateCanvasSizeRef();
+}
+
+export function decrementCols() {
+  state.colClueCount = Math.max(1, state.colClueCount - 1);
+  loadLayout();
+  initCells();
+  updateCanvasSizeRef();
+}
+
+export function incrementCols() {
+  state.colClueCount++;
+  loadLayout();
+  initCells();
+  updateCanvasSizeRef();
+}
+
+export function decrementFineTune() {
+  state.fineTune--;
+  saveLayout();
+  updateCanvasSizeRef();
+}
+
+export function incrementFineTune() {
+  state.fineTune++;
+  saveLayout();
+  updateCanvasSizeRef();
+}
+
+export function resetSizeDefaults() {
+  saveLayout();
+  state.size = 4;
+  state.rowClueCount = 1;
+  state.colClueCount = 1;
+  initCells();
+  updateCanvasSizeRef();
+}

--- a/src/overlay-ui.js
+++ b/src/overlay-ui.js
@@ -1,0 +1,427 @@
+// Manages the overlay frame, canvas rendering, ROI capture, and main action buttons.
+import { clearRenderHandle, state } from './state.js';
+import { createGrid, exportAllCells, exportCells, exportWhiteCells, onCanvasMouseDown, onCanvasMouseMove, undoLastAction, cleanAll } from './nonogram-grid.js';
+import { toggleExtraConfigPanel } from './status-controls.js';
+import { ensureProgressLoop } from './twitch-chat.js';
+import { minutesSinceRedeem, redeemAndTrack } from './twitch-redeem.js';
+
+export function sharpen(ctx, w, h, mix) {
+  let x;
+  let sx;
+  let sy;
+  let r;
+  let g;
+  let b;
+  let a;
+  let dstOff;
+  let srcOff;
+  let wt;
+  let cx;
+  let cy;
+  let scy;
+  let scx;
+  const weights = [0, -1, 0, -1, 5, -1, 0, -1, 0];
+  const katet = Math.round(Math.sqrt(weights.length));
+  const half = (katet * 0.5) | 0;
+  const dstData = ctx.createImageData(w, h);
+  const dstBuff = dstData.data;
+  const srcBuff = ctx.getImageData(0, 0, w, h).data;
+  let y = h;
+
+  while (y--) {
+    x = w;
+    while (x--) {
+      sy = y;
+      sx = x;
+      dstOff = (y * w + x) * 4;
+      r = g = b = a = 0;
+
+      for (cy = 0; cy < katet; cy++) {
+        for (cx = 0; cx < katet; cx++) {
+          scy = sy + cy - half;
+          scx = sx + cx - half;
+          if (scy >= 0 && scy < h && scx >= 0 && scx < w) {
+            srcOff = (scy * w + scx) * 4;
+            wt = weights[cy * katet + cx];
+            r += srcBuff[srcOff] * wt;
+            g += srcBuff[srcOff + 1] * wt;
+            b += srcBuff[srcOff + 2] * wt;
+            a += srcBuff[srcOff + 3] * wt;
+          }
+        }
+      }
+
+      dstBuff[dstOff] = r * mix + srcBuff[dstOff] * (1 - mix);
+      dstBuff[dstOff + 1] = g * mix + srcBuff[dstOff + 1] * (1 - mix);
+      dstBuff[dstOff + 2] = b * mix + srcBuff[dstOff + 2] * (1 - mix);
+      dstBuff[dstOff + 3] = srcBuff[dstOff + 3];
+    }
+  }
+
+  ctx.putImageData(dstData, 0, 0);
+}
+
+export function updateROI() {
+  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  if (!video) return;
+
+  state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
+
+  const actualWidth = video.videoWidth;
+  const actualHeight = video.videoHeight;
+  const roiWidth = actualWidth * state.roiWidthPercent;
+  const roiHeight = actualHeight * state.roiHeightPercent;
+  const roiX = actualWidth - roiWidth;
+  const roiY = actualHeight - roiHeight;
+
+  state.roiCtx.drawImage(video, roiX, roiY, roiWidth, roiHeight, 0, 0, state.roiCanvas.width, state.roiCanvas.height);
+
+  if (state.sharpeningEnabled) {
+    sharpen(state.roiCtx, state.roiCanvas.width, state.roiCanvas.height, 0.9);
+  }
+}
+
+export function drawStatus() {
+  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  if (!video) return;
+
+  const actualWidth = video.videoWidth;
+  const actualHeight = video.videoHeight;
+  const scaleX = actualWidth / 1920;
+  const scaleY = actualHeight / 1080;
+
+  state.statusCanvases.forEach(({ canvas: sc, ctx: sctx, region }) => {
+    const sx = region.sx * scaleX;
+    const sy = region.sy * scaleY;
+    const sw = region.sw * scaleX;
+    const sh = region.sh * scaleY;
+    sctx.clearRect(0, 0, sc.width, sc.height);
+    sctx.drawImage(video, sx, sy, sw, sh, 0, 0, sc.width, sc.height);
+  });
+}
+
+export function render() {
+  if (state.isMinimized || state.canvas.style.display === 'none') {
+    return;
+  }
+
+  state.ctx.clearRect(0, 0, state.canvas.width, state.canvas.height);
+  state.ctx.drawImage(state.roiCanvas, 0, 0);
+  createGrid();
+  if (state.statusEnabled) drawStatus();
+
+  if (!document.hidden) {
+    state.renderHandle = requestAnimationFrame(render);
+  } else {
+    state.renderHandle = setTimeout(render, 1000 / 30);
+  }
+}
+
+export function minimizeCanvas() {
+  state.isMinimized = true;
+  clearRenderHandle();
+
+  state.canvas.style.display = 'none';
+  state.frame.style.height = '0px';
+  state.frame.style.width = '0px';
+
+  const ctrl = document.getElementById('control-container');
+  if (ctrl) ctrl.style.display = 'none';
+
+  const btns = document.getElementById('button-container');
+  if (btns) btns.style.display = 'none';
+
+  const cfg = document.getElementById('config-panel');
+  if (cfg) cfg.style.display = 'none';
+
+  const extraCfg = document.getElementById('extra-config-panel');
+  if (extraCfg) extraCfg.style.display = 'none';
+
+  const statusCont = document.getElementById('status-container');
+  if (statusCont) statusCont.style.display = 'none';
+
+  const restoreBtn = document.getElementById('restore-button');
+  if (restoreBtn) restoreBtn.style.display = 'block';
+
+  if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+    state.minimizeBtn.remove();
+    state.minimizeBtn = null;
+  }
+}
+
+export function restoreCanvas() {
+  state.isMinimized = false;
+  state.canvas.style.display = 'block';
+  updateCanvasSize();
+  render();
+
+  state.frame.style.height = `${state.canvas.height * state.zoomFactor + 40}px`;
+  state.frame.style.width = `${state.canvas.width * state.zoomFactor}px`;
+
+  const ctrl = document.getElementById('control-container');
+  if (ctrl) ctrl.style.display = 'block';
+
+  const btns = document.getElementById('button-container');
+  if (btns) btns.style.display = 'flex';
+
+  const restoreBtn = document.getElementById('restore-button');
+  if (restoreBtn) restoreBtn.style.display = 'none';
+
+  const statusCont = document.getElementById('status-container');
+  if (statusCont) statusCont.style.display = state.statusEnabled ? 'block' : 'none';
+
+  if (state.showMinimizeButtons && !state.minimizeBtn) {
+    state.minimizeBtn = document.createElement('button');
+    state.minimizeBtn.textContent = 'X';
+    Object.assign(state.minimizeBtn.style, {
+      position: 'absolute',
+      top: '4px',
+      left: '4px',
+      width: '24px',
+      height: '24px',
+      fontWeight: 'bold',
+      fontSize: '16px',
+      lineHeight: '22px',
+      textAlign: 'center',
+      zIndex: 10002,
+      background: '#f0f0f0',
+      border: '1px solid #444',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      padding: '0',
+      color: 'black'
+    });
+    state.minimizeBtn.onclick = minimizeCanvas;
+    state.frame.appendChild(state.minimizeBtn);
+  }
+}
+
+export function setupCanvas() {
+  state.frame = document.createElement('div');
+  state.frame.id = 'draggable-frame';
+  state.frame.style.cssText = `
+    position: fixed; top: 20px; left: 20px; background: black;
+    border: 2px solid #555; border-radius: 8px; z-index: 1000;
+  `;
+  state.canvas = document.createElement('canvas');
+  state.canvas.id = 'canvas';
+  state.frame.appendChild(state.canvas);
+  document.body.appendChild(state.frame);
+  state.ctx = state.canvas.getContext('2d');
+
+  const restoreBtn = document.createElement('button');
+  restoreBtn.id = 'restore-button';
+  restoreBtn.textContent = 'Restore nonogram overlay';
+  Object.assign(restoreBtn.style, {
+    position: 'absolute',
+    bottom: '12px',
+    left: '12px',
+    zIndex: '10003',
+    padding: '6px 12px',
+    background: '#00cc44',
+    boxShadow: '0 0 8px #00cc44',
+    color: 'white',
+    fontWeight: 'bold',
+    border: 'none',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    display: 'none'
+  });
+  restoreBtn.onclick = () => restoreCanvas();
+
+  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  if (video && video.parentElement) {
+    video.parentElement.style.position = 'relative';
+    video.parentElement.appendChild(restoreBtn);
+  } else {
+    document.body.appendChild(restoreBtn);
+  }
+
+  if (state.showMinimizeButtons) {
+    state.minimizeBtn = document.createElement('button');
+    state.minimizeBtn.textContent = 'X';
+    Object.assign(state.minimizeBtn.style, {
+      position: 'absolute',
+      top: '4px',
+      left: '4px',
+      width: '24px',
+      height: '24px',
+      fontWeight: 'bold',
+      fontSize: '16px',
+      lineHeight: '22px',
+      textAlign: 'center',
+      zIndex: 10002,
+      background: '#f0f0f0',
+      border: '1px solid #444',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      padding: '0',
+      color: 'black'
+    });
+    state.minimizeBtn.onclick = minimizeCanvas;
+    state.frame.appendChild(state.minimizeBtn);
+  }
+
+  state.canvas.addEventListener('mousedown', onCanvasMouseDown);
+
+  state.documentMouseMoveHandler = e => {
+    if (state.isDragging) {
+      state.frame.style.left = `${e.clientX - state.dragOffsetX}px`;
+      state.frame.style.top = `${e.clientY - state.dragOffsetY}px`;
+    }
+  };
+  document.addEventListener('mousemove', state.documentMouseMoveHandler);
+
+  state.documentMouseUpHandler = () => {
+    state.isDragging = false;
+    state.isMarking = false;
+    if (state.currentAction && state.currentAction.length) {
+      state.moveHistory.push(state.currentAction);
+    }
+    state.currentAction = null;
+  };
+  document.addEventListener('mouseup', state.documentMouseUpHandler);
+
+  state.canvas.addEventListener('mousemove', onCanvasMouseMove);
+  state.canvas.addEventListener('contextmenu', e => {
+    e.preventDefault();
+  });
+}
+
+export function updateCanvasSize() {
+  const fixedWidth = Math.round(428 * (0.36 / 0.335));
+  const fixedHeight = 420;
+
+  state.canvas.width = fixedWidth;
+  state.canvas.height = fixedHeight;
+  state.roiCanvas.width = state.canvas.width;
+  state.roiCanvas.height = state.canvas.height;
+  state.canvas.style.width = `${fixedWidth * state.zoomFactor}px`;
+  state.canvas.style.height = `${fixedHeight * state.zoomFactor}px`;
+  state.frame.style.width = `${fixedWidth * state.zoomFactor}px`;
+  state.frame.style.height = `${fixedHeight * state.zoomFactor + 60}px`;
+
+  createGrid();
+  updateROI();
+}
+
+export function createMainButtons() {
+  if (state.activityBtnMonitorId) {
+    clearInterval(state.activityBtnMonitorId);
+    state.activityBtnMonitorId = null;
+  }
+
+  const container = document.createElement('div');
+  container.id = 'button-container';
+  container.style.cssText = `
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    padding: 6px 8px;
+    z-index: 10001;
+    pointer-events: auto;
+    background: rgba(0,0,0,0.5);
+    border-top: 1px solid #333;
+  `;
+  state.frame.appendChild(container);
+
+  const makeBtn = (label, onClick) => {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.style.cssText = `
+      padding: 4px 8px;
+      background: #fff;
+      border: 1px solid #000;
+      border-radius: 3px;
+      font-size: 13px;
+      color: black;
+      cursor: pointer;
+      transition: background 0.15s ease, opacity 0.15s ease;
+    `;
+    btn.onmouseenter = () => {
+      btn.style.background = '#f0f0f0';
+    };
+    btn.onmouseleave = () => {
+      btn.style.background = '#fff';
+    };
+    btn.onclick = onClick;
+    return btn;
+  };
+
+  state.exportFillBtn = container.appendChild(makeBtn('Export !fill', exportCells));
+  state.exportEmptyBtn = container.appendChild(makeBtn('Export !empty', exportWhiteCells));
+  container.appendChild(makeBtn('Undo', undoLastAction));
+
+  const spacer = document.createElement('div');
+  spacer.style.flex = '1';
+  container.appendChild(spacer);
+
+  container.appendChild(makeBtn('reset export', exportAllCells));
+  container.appendChild(makeBtn('Clean grid', cleanAll));
+  container.appendChild(makeBtn('⚙️ Config', () => {
+    toggleExtraConfigPanel();
+  }));
+
+  const updateActivityBtnStyle = btn => {
+    const mins = minutesSinceRedeem();
+    if (isNaN(mins) || mins < 30) {
+      btn.dataset.alert = '';
+      btn.style.background = '#fff';
+      btn.style.color = 'black';
+      btn.style.border = '1px solid #000';
+    } else if (mins >= 30 && mins <= 45) {
+      btn.dataset.alert = 'warning';
+      btn.style.background = '#ff4444';
+      btn.style.color = 'white';
+      btn.style.border = '1px solid #cc0000';
+    } else {
+      btn.dataset.alert = 'overdue';
+      btn.style.background = '#b22222';
+      btn.style.color = 'white';
+      btn.style.border = '1px solid #800000';
+    }
+  };
+
+  const activityBtn = makeBtn('🎟️ Activity Coupon', async () => {
+    if (activityBtn.disabled) return;
+    try {
+      activityBtn.disabled = true;
+      activityBtn.style.opacity = '0.7';
+      activityBtn.textContent = '⏳ Redeeming...';
+      await redeemAndTrack(() => updateActivityBtnStyle(activityBtn));
+    } catch (e) {
+      console.error('Redeem error:', e);
+    } finally {
+      activityBtn.textContent = '🎟️ Activity Coupon';
+      activityBtn.disabled = false;
+      activityBtn.style.opacity = '1';
+      updateActivityBtnStyle(activityBtn);
+      state.activityBtnMonitorId = setInterval(() => {
+        updateActivityBtnStyle(activityBtn);
+      }, 30_000);
+    }
+  });
+
+  activityBtn.onmouseenter = () => {
+    const alertState = activityBtn.dataset.alert;
+    if (!alertState) activityBtn.style.background = '#f0f0f0';
+    else if (alertState === 'warning') activityBtn.style.background = '#ff2a2a';
+    else if (alertState === 'overdue') activityBtn.style.background = '#8b1a1a';
+  };
+  activityBtn.onmouseleave = () => {
+    updateActivityBtnStyle(activityBtn);
+  };
+
+  container.appendChild(activityBtn);
+  updateActivityBtnStyle(activityBtn);
+  state.activityBtnMonitorId = setInterval(() => {
+    updateActivityBtnStyle(activityBtn);
+  }, 30_000);
+
+  if (state.autosendEnabled) {
+    ensureProgressLoop();
+  }
+}

--- a/src/overlay-ui.js
+++ b/src/overlay-ui.js
@@ -5,6 +5,42 @@ import { toggleExtraConfigPanel } from './status-controls.js';
 import { ensureProgressLoop } from './twitch-chat.js';
 import { minutesSinceRedeem, redeemAndTrack } from './twitch-redeem.js';
 
+const MINIMIZE_BUTTON_STYLE = {
+  position: 'absolute',
+  top: '4px',
+  left: '4px',
+  width: '24px',
+  height: '24px',
+  fontWeight: 'bold',
+  fontSize: '16px',
+  lineHeight: '22px',
+  textAlign: 'center',
+  zIndex: 10002,
+  background: '#f0f0f0',
+  border: '1px solid #444',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  padding: '0',
+  color: 'black'
+};
+
+function createMinimizeButton(onClick) {
+  const button = document.createElement('button');
+  button.textContent = 'X';
+  Object.assign(button.style, MINIMIZE_BUTTON_STYLE);
+  button.onclick = onClick;
+  return button;
+}
+
+function getVideoElement() {
+  if (state.videoEl?.isConnected && state.videoEl.readyState >= 2) {
+    return state.videoEl;
+  }
+
+  state.videoEl = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
+  return state.videoEl;
+}
+
 export function sharpen(ctx, w, h, mix) {
   let x;
   let sx;
@@ -62,7 +98,7 @@ export function sharpen(ctx, w, h, mix) {
 }
 
 export function updateROI() {
-  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  const video = getVideoElement();
   if (!video) return;
 
   state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
@@ -82,7 +118,7 @@ export function updateROI() {
 }
 
 export function drawStatus() {
-  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  const video = getVideoElement();
   if (!video) return;
 
   const actualWidth = video.videoWidth;
@@ -131,9 +167,6 @@ export function minimizeCanvas() {
   const btns = document.getElementById('button-container');
   if (btns) btns.style.display = 'none';
 
-  const cfg = document.getElementById('config-panel');
-  if (cfg) cfg.style.display = 'none';
-
   const extraCfg = document.getElementById('extra-config-panel');
   if (extraCfg) extraCfg.style.display = 'none';
 
@@ -171,27 +204,7 @@ export function restoreCanvas() {
   if (statusCont) statusCont.style.display = state.statusEnabled ? 'block' : 'none';
 
   if (state.showMinimizeButtons && !state.minimizeBtn) {
-    state.minimizeBtn = document.createElement('button');
-    state.minimizeBtn.textContent = 'X';
-    Object.assign(state.minimizeBtn.style, {
-      position: 'absolute',
-      top: '4px',
-      left: '4px',
-      width: '24px',
-      height: '24px',
-      fontWeight: 'bold',
-      fontSize: '16px',
-      lineHeight: '22px',
-      textAlign: 'center',
-      zIndex: 10002,
-      background: '#f0f0f0',
-      border: '1px solid #444',
-      borderRadius: '4px',
-      cursor: 'pointer',
-      padding: '0',
-      color: 'black'
-    });
-    state.minimizeBtn.onclick = minimizeCanvas;
+    state.minimizeBtn = createMinimizeButton(minimizeCanvas);
     state.frame.appendChild(state.minimizeBtn);
   }
 }
@@ -229,7 +242,7 @@ export function setupCanvas() {
   });
   restoreBtn.onclick = () => restoreCanvas();
 
-  const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+  const video = getVideoElement();
   if (video && video.parentElement) {
     video.parentElement.style.position = 'relative';
     video.parentElement.appendChild(restoreBtn);
@@ -238,27 +251,7 @@ export function setupCanvas() {
   }
 
   if (state.showMinimizeButtons) {
-    state.minimizeBtn = document.createElement('button');
-    state.minimizeBtn.textContent = 'X';
-    Object.assign(state.minimizeBtn.style, {
-      position: 'absolute',
-      top: '4px',
-      left: '4px',
-      width: '24px',
-      height: '24px',
-      fontWeight: 'bold',
-      fontSize: '16px',
-      lineHeight: '22px',
-      textAlign: 'center',
-      zIndex: 10002,
-      background: '#f0f0f0',
-      border: '1px solid #444',
-      borderRadius: '4px',
-      cursor: 'pointer',
-      padding: '0',
-      color: 'black'
-    });
-    state.minimizeBtn.onclick = minimizeCanvas;
+    state.minimizeBtn = createMinimizeButton(minimizeCanvas);
     state.frame.appendChild(state.minimizeBtn);
   }
 

--- a/src/overlay-ui.js
+++ b/src/overlay-ui.js
@@ -33,12 +33,7 @@ function createMinimizeButton(onClick) {
 }
 
 export function getVideoElement() {
-  if (state.videoEl?.isConnected && state.videoEl.readyState >= 2) {
-    return state.videoEl;
-  }
-
-  state.videoEl = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
-  return state.videoEl;
+  return [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
 }
 
 export function sharpen(ctx, w, h, mix) {

--- a/src/overlay-ui.js
+++ b/src/overlay-ui.js
@@ -32,7 +32,7 @@ function createMinimizeButton(onClick) {
   return button;
 }
 
-function getVideoElement() {
+export function getVideoElement() {
   if (state.videoEl?.isConnected && state.videoEl.readyState >= 2) {
     return state.videoEl;
   }
@@ -99,7 +99,7 @@ export function sharpen(ctx, w, h, mix) {
 
 export function updateROI() {
   const video = getVideoElement();
-  if (!video) return;
+  if (!video || state.isPaused) return;
 
   state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
 
@@ -320,6 +320,7 @@ export function createMainButtons() {
     border-top: 1px solid #333;
   `;
   state.frame.appendChild(container);
+  state.buttonContainer = container;
 
   const makeBtn = (label, onClick) => {
     const btn = document.createElement('button');

--- a/src/state.js
+++ b/src/state.js
@@ -15,9 +15,7 @@ export const state = {
   roiCtx: null,
   DEFAULT_CONF: { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 },
   size: 4,
-  rowClueCount: 1,
   colClueCount: 1,
-  ratio: 1.0,
   anchorX: 10,
   anchorY: 10,
   zoomFactor: 1.4,
@@ -26,6 +24,7 @@ export const state = {
   roiHeightPercent: 0.584,
   configs: {},
   autosendEnabled: false,
+  videoEl: null,
   canvas: null,
   ctx: null,
   frame: null,
@@ -45,6 +44,7 @@ export const state = {
   minimizeBtn: null,
   moveHistory: [],
   currentAction: null,
+  geometryCache: null,
   lastDartExportIndex: 1,
   COOLDOWN_MS: 10_000,
   nextSendAt: 0,
@@ -57,17 +57,12 @@ export const state = {
   statusAltCmd: false,
   rowDashes: [],
   colDashes: [],
-  redeemBtn: null,
   lastGuardRedeem: 0,
   REDEEM_KEY: 'lastRedeemTimestamp',
-  redeemButtonMonitorId: null,
   activityBtnMonitorId: null,
   redeemBusy: false,
-  autoRedeemEnabled: false,
-  autoRedeemTimer: null,
-  busy: false,
   statusCanvases: [],
-  current_chat: null,
+  currentChat: null,
   labelMap: {},
   controlSections: [],
   roiInterval: null,
@@ -95,7 +90,7 @@ export function initState() {
   state.statusEnabled = state.uiConfig.statusEnabled;
   state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
   state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
-  state.guard_Export = state.uiConfig.guardExport;
+  state.guardExport = state.uiConfig.guardExport;
   state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
 }
 
@@ -218,8 +213,8 @@ export const statusRegions = [
   { sx: 800, sy: 980, sw: 250, sh: 70 }
 ];
 
-export function getKey(sz, rc, cc) {
-  return `${sz}x${rc}x${cc}`;
+export function getKey(sz, cc) {
+  return `${sz}x${cc}`;
 }
 
 export function getLayoutSettings(size, colClueLength) {
@@ -237,14 +232,12 @@ export function getLayoutSettings(size, colClueLength) {
 }
 
 export function saveLayout() {
-  const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+  const key = getKey(state.size, state.colClueCount);
   state.configs[key] = {
-    ratio: state.ratio,
     anchorX: state.anchorX,
     anchorY: state.anchorY,
     fineTune: state.fineTune,
     size: state.size,
-    rowClueCount: state.rowClueCount,
     colClueCount: state.colClueCount
   };
   localStorage.setItem('nonogramConfigMap', JSON.stringify(state.configs));
@@ -256,7 +249,7 @@ export function loadLayout() {
     state.anchorX = layout.anchorX;
     state.anchorY = layout.anchorY;
   }
-  const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+  const key = getKey(state.size, state.colClueCount);
   const saved = state.configs[key];
   if (saved) {
     state.fineTune = saved.fineTune ?? state.fineTune;

--- a/src/state.js
+++ b/src/state.js
@@ -28,6 +28,7 @@ export const state = {
   canvas: null,
   ctx: null,
   frame: null,
+  buttonContainer: null,
   isDragging: false,
   dragOffsetX: 0,
   dragOffsetY: 0,
@@ -40,6 +41,7 @@ export const state = {
   markValue: 0,
   eraseMode: false,
   isMinimized: false,
+  isPaused: false,
   renderHandle: null,
   minimizeBtn: null,
   moveHistory: [],
@@ -66,6 +68,7 @@ export const state = {
   labelMap: {},
   controlSections: [],
   roiInterval: null,
+  autoRedeemTimer: null,
   documentMouseMoveHandler: null,
   documentMouseUpHandler: null
 };

--- a/src/state.js
+++ b/src/state.js
@@ -24,7 +24,6 @@ export const state = {
   roiHeightPercent: 0.584,
   configs: {},
   autosendEnabled: false,
-  videoEl: null,
   canvas: null,
   ctx: null,
   frame: null,

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,5 @@
 // Holds shared runtime state, persistent config, and layout constants used across modules.
-export const state = {
-  uiConfig: JSON.parse(localStorage.getItem('nonogramUIConfig')) || {
+const DEFAULT_UI_CONFIG = {
     showMinimizeButtons: false,
     useBlueFill: false,
     statusEnabled: false,
@@ -8,8 +7,11 @@ export const state = {
     sharpeningEnabled: false,
     autosendEnabled: false,
     guardExport: false
-  },
-  roiCanvas: document.createElement('canvas'),
+  };
+
+export const state = {
+  uiConfig: { ...DEFAULT_UI_CONFIG },
+  roiCanvas: null,
   roiCtx: null,
   DEFAULT_CONF: { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 },
   size: 4,
@@ -22,7 +24,7 @@ export const state = {
   fineTune: 0,
   roiWidthPercent: 0.36,
   roiHeightPercent: 0.584,
-  configs: JSON.parse(localStorage.getItem('nonogramConfigMap')) || {},
+  configs: {},
   autosendEnabled: false,
   canvas: null,
   ctx: null,
@@ -73,22 +75,29 @@ export const state = {
   documentMouseUpHandler: null
 };
 
-if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
-  state.uiConfig.sharpeningEnabled = false;
-}
+export function initState() {
+  const storedUIConfig = JSON.parse(localStorage.getItem('nonogramUIConfig') || 'null') || {};
+  state.uiConfig = { ...DEFAULT_UI_CONFIG, ...storedUIConfig };
 
-state.roiCtx = state.roiCanvas.getContext('2d');
-state.anchorX = state.DEFAULT_CONF.anchorX;
-state.anchorY = state.DEFAULT_CONF.anchorY;
-state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
-state.fineTune = state.DEFAULT_CONF.fineTune;
-state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
-state.useBlueFill = state.uiConfig.useBlueFill;
-state.statusEnabled = state.uiConfig.statusEnabled;
-state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
-state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
-state.guard_Export = state.uiConfig.guardExport;
-state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
+  if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
+    state.uiConfig.sharpeningEnabled = false;
+  }
+
+  state.configs = JSON.parse(localStorage.getItem('nonogramConfigMap') || 'null') || {};
+  state.roiCanvas = document.createElement('canvas');
+  state.roiCtx = state.roiCanvas.getContext('2d');
+  state.anchorX = state.DEFAULT_CONF.anchorX;
+  state.anchorY = state.DEFAULT_CONF.anchorY;
+  state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
+  state.fineTune = state.DEFAULT_CONF.fineTune;
+  state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
+  state.useBlueFill = state.uiConfig.useBlueFill;
+  state.statusEnabled = state.uiConfig.statusEnabled;
+  state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
+  state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
+  state.guard_Export = state.uiConfig.guardExport;
+  state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
+}
 
 export function saveUIConfig() {
   localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,265 @@
+// Holds shared runtime state, persistent config, and layout constants used across modules.
+export const state = {
+  uiConfig: JSON.parse(localStorage.getItem('nonogramUIConfig')) || {
+    showMinimizeButtons: false,
+    useBlueFill: false,
+    statusEnabled: false,
+    fineTuningEnabled: false,
+    sharpeningEnabled: false,
+    autosendEnabled: false,
+    guardExport: false
+  },
+  roiCanvas: document.createElement('canvas'),
+  roiCtx: null,
+  DEFAULT_CONF: { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 },
+  size: 4,
+  rowClueCount: 1,
+  colClueCount: 1,
+  ratio: 1.0,
+  anchorX: 10,
+  anchorY: 10,
+  zoomFactor: 1.4,
+  fineTune: 0,
+  roiWidthPercent: 0.36,
+  roiHeightPercent: 0.584,
+  configs: JSON.parse(localStorage.getItem('nonogramConfigMap')) || {},
+  autosendEnabled: false,
+  canvas: null,
+  ctx: null,
+  frame: null,
+  isDragging: false,
+  dragOffsetX: 0,
+  dragOffsetY: 0,
+  lastExported: new Set(),
+  lastExportedWhite: new Set(),
+  cellStates: [],
+  hoveredRow: -1,
+  hoveredCol: -1,
+  isMarking: false,
+  markValue: 0,
+  eraseMode: false,
+  isMinimized: false,
+  renderHandle: null,
+  minimizeBtn: null,
+  moveHistory: [],
+  currentAction: null,
+  lastDartExportIndex: 1,
+  COOLDOWN_MS: 10_000,
+  nextSendAt: 0,
+  sendQueue: [],
+  sendLoopTimer: null,
+  progressTimer: null,
+  exportFillBtn: null,
+  exportEmptyBtn: null,
+  exportDartBtn: null,
+  statusAltCmd: false,
+  rowDashes: [],
+  colDashes: [],
+  redeemBtn: null,
+  lastGuardRedeem: 0,
+  REDEEM_KEY: 'lastRedeemTimestamp',
+  redeemButtonMonitorId: null,
+  activityBtnMonitorId: null,
+  redeemBusy: false,
+  autoRedeemEnabled: false,
+  autoRedeemTimer: null,
+  busy: false,
+  statusCanvases: [],
+  current_chat: null,
+  labelMap: {},
+  controlSections: [],
+  roiInterval: null,
+  documentMouseMoveHandler: null,
+  documentMouseUpHandler: null
+};
+
+if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
+  state.uiConfig.sharpeningEnabled = false;
+}
+
+state.roiCtx = state.roiCanvas.getContext('2d');
+state.anchorX = state.DEFAULT_CONF.anchorX;
+state.anchorY = state.DEFAULT_CONF.anchorY;
+state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
+state.fineTune = state.DEFAULT_CONF.fineTune;
+state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
+state.useBlueFill = state.uiConfig.useBlueFill;
+state.statusEnabled = state.uiConfig.statusEnabled;
+state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
+state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
+state.guard_Export = state.uiConfig.guardExport;
+state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
+
+export function saveUIConfig() {
+  localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
+}
+
+export const sizeLookup = {
+  '4_1': { cellSize: 90.7, anchorX: 1, anchorY: 10 },
+  '4_2': { cellSize: 85.3, anchorX: 1, anchorY: 10 },
+  '5_1': { cellSize: 73.3, anchorX: 1, anchorY: 10 },
+  '5_2': { cellSize: 69.3, anchorX: 1, anchorY: 10 },
+  '5_3': { cellSize: 65.3, anchorX: 1, anchorY: 10 },
+  '6_1': { cellSize: 61.3, anchorX: 1, anchorY: 10 },
+  '6_2': { cellSize: 57.3, anchorX: 1, anchorY: 10 },
+  '6_3': { cellSize: 54.6, anchorX: 1, anchorY: 10 },
+  '7_1': { cellSize: 51.9, anchorX: 1, anchorY: 10 },
+  '7_2': { cellSize: 49.5, anchorX: 1, anchorY: 10 },
+  '7_3': { cellSize: 46.7, anchorX: 1, anchorY: 10 },
+  '7_4': { cellSize: 44.1, anchorX: 1, anchorY: 10 },
+  '8_1': { cellSize: 45.3, anchorX: 1, anchorY: 10 },
+  '8_2': { cellSize: 42.7, anchorX: 1, anchorY: 10 },
+  '8_3': { cellSize: 41.3, anchorX: 1, anchorY: 10 },
+  '8_4': { cellSize: 38.7, anchorX: 1, anchorY: 10 },
+  '9_1': { cellSize: 40, anchorX: 1, anchorY: 10 },
+  '9_2': { cellSize: 38.7, anchorX: 1, anchorY: 10 },
+  '9_3': { cellSize: 37.3, anchorX: 1, anchorY: 10 },
+  '9_4': { cellSize: 34.7, anchorX: 1, anchorY: 10 },
+  '9_5': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+  '10_1': { cellSize: 36, anchorX: 1, anchorY: 10 },
+  '10_2': { cellSize: 34.7, anchorX: 1, anchorY: 10 },
+  '10_3': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+  '10_4': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+  '10_5': { cellSize: 29.3, anchorX: 1, anchorY: 10 },
+  '11_1': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+  '11_2': { cellSize: 32, anchorX: 1, anchorY: 10 },
+  '11_3': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+  '11_4': { cellSize: 29.4, anchorX: 1.75, anchorY: 10 },
+  '11_5': { cellSize: 28, anchorX: 1.75, anchorY: 10 },
+  '11_6': { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
+  '12_1': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+  '12_2': { cellSize: 29.3, anchorX: 1, anchorY: 10 },
+  '12_3': { cellSize: 28, anchorX: 1, anchorY: 10 },
+  '12_4': { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
+  '12_5': { cellSize: 25.3, anchorX: 1.75, anchorY: 10 },
+  '12_6': { cellSize: 24.1, anchorX: 1.75, anchorY: 10 },
+  '13_1': { cellSize: 28, anchorX: 1, anchorY: 10 },
+  '13_2': { cellSize: 26.7, anchorX: 1, anchorY: 10 },
+  '13_3': { cellSize: 25.4, anchorX: 1, anchorY: 10 },
+  '13_4': { cellSize: 25.4, anchorX: 1.5, anchorY: 10 },
+  '13_5': { cellSize: 24, anchorX: 1.5, anchorY: 10 },
+  '13_6': { cellSize: 22.7, anchorX: 1.5, anchorY: 10 },
+  '13_7': { cellSize: 21.4, anchorX: 1, anchorY: 10 },
+  '14_1': { cellSize: 26.7, anchorX: 1, anchorY: 10 },
+  '14_2': { cellSize: 25.3, anchorX: 1.5, anchorY: 10 },
+  '14_3': { cellSize: 24, anchorX: 1, anchorY: 10 },
+  '14_4': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+  '14_5': { cellSize: 21.3, anchorX: 1, anchorY: 10 },
+  '14_6': { cellSize: 21.4, anchorX: 1.5, anchorY: 10 },
+  '14_7': { cellSize: 20, anchorX: 1, anchorY: 10 },
+  '15_1': { cellSize: 24, anchorX: 1, anchorY: 10 },
+  '15_2': { cellSize: 24, anchorX: 1.5, anchorY: 10 },
+  '15_3': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+  '15_4': { cellSize: 21.3, anchorX: 4, anchorY: 10 },
+  '15_5': { cellSize: 21.3, anchorX: 1.5, anchorY: 10 },
+  '15_6': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+  '15_7': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '15_8': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '16_1': { cellSize: 22.6, anchorX: 1, anchorY: 10 },
+  '16_2': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+  '16_3': { cellSize: 21.3, anchorX: 1.25, anchorY: 10 },
+  '16_4': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+  '16_5': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+  '16_6': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '16_7': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+  '16_8': { cellSize: 17.4, anchorX: 1.5, anchorY: 10 },
+  '17_1': { cellSize: 21.3, anchorX: 1, anchorY: 10 },
+  '17_2': { cellSize: 21.4, anchorX: 1, anchorY: 10 },
+  '17_3': { cellSize: 20, anchorX: 1, anchorY: 10 },
+  '17_4': { cellSize: 18.7, anchorX: 1, anchorY: 10 },
+  '17_5': { cellSize: 18.7, anchorX: 1, anchorY: 10 },
+  '17_6': { cellSize: 17.3, anchorX: 1.75, anchorY: 10 },
+  '17_7': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+  '17_8': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+  '17_9': { cellSize: 14.7, anchorX: 1.5, anchorY: 10 },
+  '18_1': { cellSize: 20, anchorX: 1, anchorY: 10 },
+  '18_2': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+  '18_3': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '18_4': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '18_5': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+  '18_6': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+  '18_7': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+  '18_8': { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
+  '18_9': { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
+  '19_1': { cellSize: 18.6, anchorX: 1.5, anchorY: 10.5 },
+  '19_2': { cellSize: 18.6, anchorX: 4, anchorY: 10.5 },
+  '19_3': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+  '19_4': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+  '19_5': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+  '19_6': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+  '19_7': { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
+  '19_8': { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
+  '19_9': { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
+  '19_10': { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
+  '20_1': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+  '20_2': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+  '20_3': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+  '20_4': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+  '20_5': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+  '20_6': { cellSize: 14.65, anchorX: 1.5, anchorY: 10 },
+  '20_7': { cellSize: 14.6, anchorX: 1.5, anchorY: 10 },
+  '20_8': { cellSize: 13.3, anchorX: 1.75, anchorY: 10 },
+  '20_9': { cellSize: 13.3, anchorX: 1.5, anchorY: 10 },
+  '20_10': { cellSize: 12, anchorX: 1.5, anchorY: 10 }
+};
+
+export const statusRegions = [
+  { sx: 200, sy: 980, sw: 250, sh: 70 },
+  { sx: 500, sy: 980, sw: 250, sh: 70 },
+  { sx: 800, sy: 980, sw: 250, sh: 70 }
+];
+
+export function getKey(sz, rc, cc) {
+  return `${sz}x${rc}x${cc}`;
+}
+
+export function getLayoutSettings(size, colClueLength) {
+  const key = `${size}_${colClueLength}`;
+  const entry = sizeLookup[key];
+  if (!entry) {
+    console.warn(`No layout settings found for size=${size}, colClueLength=${colClueLength}`);
+    return null;
+  }
+  return {
+    cellSize: entry.cellSize,
+    anchorX: entry.anchorX,
+    anchorY: entry.anchorY
+  };
+}
+
+export function saveLayout() {
+  const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+  state.configs[key] = {
+    ratio: state.ratio,
+    anchorX: state.anchorX,
+    anchorY: state.anchorY,
+    fineTune: state.fineTune,
+    size: state.size,
+    rowClueCount: state.rowClueCount,
+    colClueCount: state.colClueCount
+  };
+  localStorage.setItem('nonogramConfigMap', JSON.stringify(state.configs));
+}
+
+export function loadLayout() {
+  const layout = getLayoutSettings(state.size, state.colClueCount);
+  if (layout) {
+    state.anchorX = layout.anchorX;
+    state.anchorY = layout.anchorY;
+  }
+  const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+  const saved = state.configs[key];
+  if (saved) {
+    state.fineTune = saved.fineTune ?? state.fineTune;
+  }
+}
+
+export function clearRenderHandle() {
+  if (!state.renderHandle) return;
+  if (typeof state.renderHandle === 'number') {
+    cancelAnimationFrame(state.renderHandle);
+  } else {
+    clearTimeout(state.renderHandle);
+  }
+  state.renderHandle = null;
+}

--- a/src/status-controls.js
+++ b/src/status-controls.js
@@ -1,5 +1,5 @@
 // Builds the side controls, extra settings panel, and clickable status preview canvases.
-import { saveLayout, saveUIConfig, state, statusRegions } from './state.js';
+import { saveUIConfig, state, statusRegions } from './state.js';
 import {
   decrementCols,
   decrementFineTune,
@@ -8,10 +8,56 @@ import {
   incrementCols,
   incrementFineTune,
   incrementSize,
-  initCells,
   resetSizeDefaults
 } from './nonogram-grid.js';
-import { ensureProgressLoop, ensureSendLoop, send_message_with_event, stopProgressLoop } from './twitch-chat.js';
+import { ensureProgressLoop, ensureSendLoop, sendMessageWithEvent, stopProgressLoop } from './twitch-chat.js';
+
+const MINIMIZE_BUTTON_STYLE = {
+  position: 'absolute',
+  top: '4px',
+  left: '4px',
+  width: '24px',
+  height: '24px',
+  fontWeight: 'bold',
+  fontSize: '16px',
+  lineHeight: '22px',
+  textAlign: 'center',
+  zIndex: 10002,
+  background: '#f0f0f0',
+  border: '1px solid #444',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  padding: '0',
+  color: 'black'
+};
+
+function createCheckboxOption({ id, checked, label, onChange, marginTop = '8px' }) {
+  const wrapper = document.createElement('div');
+  wrapper.style.marginTop = marginTop;
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.id = id;
+  checkbox.checked = checked;
+  checkbox.style.marginRight = '6px';
+  checkbox.addEventListener('change', () => onChange(checkbox.checked));
+
+  const labelElement = document.createElement('label');
+  labelElement.htmlFor = id;
+  labelElement.textContent = label;
+
+  wrapper.appendChild(checkbox);
+  wrapper.appendChild(labelElement);
+  return { wrapper, checkbox };
+}
+
+function createMinimizeButton(onClick) {
+  const button = document.createElement('button');
+  button.textContent = 'X';
+  Object.assign(button.style, MINIMIZE_BUTTON_STYLE);
+  button.onclick = onClick;
+  return button;
+}
 
 let updateCanvasSizeRef;
 let createGridRef;
@@ -220,176 +266,109 @@ export function createExtraConfigPanel() {
     width: 200px;
   `;
 
-  const minDiv = document.createElement('div');
-  const minChk = document.createElement('input');
-  minChk.type = 'checkbox';
-  minChk.id = 'chk-minimize';
-  minChk.checked = state.showMinimizeButtons;
-  minChk.style.marginRight = '6px';
-  minChk.addEventListener('change', () => {
-    state.showMinimizeButtons = minChk.checked;
-    state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
-    saveUIConfig();
-    if (state.showMinimizeButtons) {
-      if (!state.minimizeBtn && !state.isMinimized) {
-        state.minimizeBtn = document.createElement('button');
-        state.minimizeBtn.textContent = 'X';
-        Object.assign(state.minimizeBtn.style, {
-          position: 'absolute',
-          top: '4px',
-          left: '4px',
-          width: '24px',
-          height: '24px',
-          fontWeight: 'bold',
-          fontSize: '16px',
-          lineHeight: '22px',
-          textAlign: 'center',
-          zIndex: 10002,
-          background: '#f0f0f0',
-          border: '1px solid #444',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          padding: '0',
-          color: 'black'
-        });
-        state.minimizeBtn.onclick = minimizeCanvasRef;
-        state.frame.appendChild(state.minimizeBtn);
+  const { wrapper: minDiv } = createCheckboxOption({
+    id: 'chk-minimize',
+    checked: state.showMinimizeButtons,
+    label: 'Enable minimize/restore',
+    marginTop: '0',
+    onChange: checked => {
+      state.showMinimizeButtons = checked;
+      state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
+      saveUIConfig();
+      if (state.showMinimizeButtons) {
+        if (!state.minimizeBtn && !state.isMinimized) {
+          state.minimizeBtn = createMinimizeButton(minimizeCanvasRef);
+          state.frame.appendChild(state.minimizeBtn);
+        }
+      } else {
+        if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+          state.minimizeBtn.remove();
+          state.minimizeBtn = null;
+        }
+        const restoreBtn = document.getElementById('restore-button');
+        if (restoreBtn) restoreBtn.style.display = 'none';
       }
-    } else {
-      if (state.minimizeBtn && state.minimizeBtn.parentElement) {
-        state.minimizeBtn.remove();
-        state.minimizeBtn = null;
+    }
+  });
+
+  const { wrapper: blueDiv } = createCheckboxOption({
+    id: 'chk-bluefill',
+    checked: state.useBlueFill,
+    label: 'Use blue fill color',
+    onChange: checked => {
+      state.useBlueFill = checked;
+      state.uiConfig.useBlueFill = state.useBlueFill;
+      saveUIConfig();
+      createGridRef();
+    }
+  });
+
+  const { wrapper: statusDivToggle } = createCheckboxOption({
+    id: 'chk-status',
+    checked: state.statusEnabled,
+    label: 'Status canvas',
+    onChange: checked => {
+      state.statusEnabled = checked;
+      state.uiConfig.statusEnabled = state.statusEnabled;
+      saveUIConfig();
+      const scCont = document.getElementById('status-container');
+      if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
+    }
+  });
+
+  const { wrapper: autosendDiv } = createCheckboxOption({
+    id: 'chk-autosend',
+    checked: state.autosendEnabled,
+    label: 'Auto-send chat commands',
+    onChange: checked => {
+      state.autosendEnabled = checked;
+      state.uiConfig.autosendEnabled = state.autosendEnabled;
+      saveUIConfig();
+      if (state.autosendEnabled) {
+        ensureSendLoop();
+        ensureProgressLoop();
+      } else {
+        stopProgressLoop();
       }
-      const restoreBtn = document.getElementById('restore-button');
-      if (restoreBtn) restoreBtn.style.display = 'none';
     }
   });
-  const minLabel = document.createElement('label');
-  minLabel.htmlFor = 'chk-minimize';
-  minLabel.textContent = 'Enable minimize/restore';
-  minDiv.appendChild(minChk);
-  minDiv.appendChild(minLabel);
 
-  const blueDiv = document.createElement('div');
-  blueDiv.style.marginTop = '8px';
-  const blueChk = document.createElement('input');
-  blueChk.type = 'checkbox';
-  blueChk.id = 'chk-bluefill';
-  blueChk.checked = state.useBlueFill;
-  blueChk.style.marginRight = '6px';
-  blueChk.addEventListener('change', () => {
-    state.useBlueFill = blueChk.checked;
-    state.uiConfig.useBlueFill = state.useBlueFill;
-    saveUIConfig();
-    createGridRef();
-  });
-  const blueLabel = document.createElement('label');
-  blueLabel.htmlFor = 'chk-bluefill';
-  blueLabel.textContent = 'Use blue fill color';
-  blueDiv.appendChild(blueChk);
-  blueDiv.appendChild(blueLabel);
-
-  const statusDivToggle = document.createElement('div');
-  statusDivToggle.style.marginTop = '8px';
-  const statusChk = document.createElement('input');
-  statusChk.type = 'checkbox';
-  statusChk.id = 'chk-status';
-  statusChk.checked = state.statusEnabled;
-  statusChk.style.marginRight = '6px';
-  statusChk.addEventListener('change', () => {
-    state.statusEnabled = statusChk.checked;
-    state.uiConfig.statusEnabled = state.statusEnabled;
-    saveUIConfig();
-    const scCont = document.getElementById('status-container');
-    if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
-  });
-  const statusLabel = document.createElement('label');
-  statusLabel.htmlFor = 'chk-status';
-  statusLabel.textContent = 'Status canvas';
-  statusDivToggle.appendChild(statusChk);
-  statusDivToggle.appendChild(statusLabel);
-
-  const autosendDiv = document.createElement('div');
-  autosendDiv.style.marginTop = '8px';
-  const autosendChk = document.createElement('input');
-  autosendChk.type = 'checkbox';
-  autosendChk.id = 'chk-autosend';
-  autosendChk.checked = state.autosendEnabled;
-  autosendChk.style.marginRight = '6px';
-  autosendChk.addEventListener('change', () => {
-    state.autosendEnabled = autosendChk.checked;
-    state.uiConfig.autosendEnabled = state.autosendEnabled;
-    saveUIConfig();
-    if (state.autosendEnabled) {
-      ensureSendLoop();
-      ensureProgressLoop();
-    } else {
-      stopProgressLoop();
+  const { wrapper: fineDiv } = createCheckboxOption({
+    id: 'chk-fine',
+    checked: state.fineTuningEnabled,
+    label: 'Enable fine-tune controls',
+    onChange: checked => {
+      state.fineTuningEnabled = checked;
+      state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
+      saveUIConfig();
+      const fineSection = document.getElementById('section-fine');
+      if (fineSection) {
+        fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+      }
     }
   });
-  const autosendLabel = document.createElement('label');
-  autosendLabel.htmlFor = 'chk-autosend';
-  autosendLabel.textContent = 'Auto-send chat commands';
-  autosendDiv.appendChild(autosendChk);
-  autosendDiv.appendChild(autosendLabel);
 
-  const fineDiv = document.createElement('div');
-  fineDiv.style.marginTop = '8px';
-  const fineChk = document.createElement('input');
-  fineChk.type = 'checkbox';
-  fineChk.id = 'chk-fine';
-  fineChk.checked = state.fineTuningEnabled;
-  fineChk.style.marginRight = '6px';
-  fineChk.addEventListener('change', () => {
-    state.fineTuningEnabled = fineChk.checked;
-    state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
-    saveUIConfig();
-    const fineSection = document.getElementById('section-fine');
-    if (fineSection) {
-      fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+  const { wrapper: sharpenDiv } = createCheckboxOption({
+    id: 'chk-sharpen',
+    checked: state.sharpeningEnabled,
+    label: 'Enable sharpen filter',
+    onChange: checked => {
+      state.sharpeningEnabled = checked;
+      state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
+      saveUIConfig();
     }
   });
-  const fineLabel = document.createElement('label');
-  fineLabel.htmlFor = 'chk-fine';
-  fineLabel.textContent = 'Enable fine-tune controls';
-  fineDiv.appendChild(fineChk);
-  fineDiv.appendChild(fineLabel);
 
-  const sharpenDiv = document.createElement('div');
-  sharpenDiv.style.marginTop = '8px';
-  const sharpenChk = document.createElement('input');
-  sharpenChk.type = 'checkbox';
-  sharpenChk.id = 'chk-sharpen';
-  sharpenChk.checked = state.sharpeningEnabled;
-  sharpenChk.style.marginRight = '6px';
-  sharpenChk.addEventListener('change', () => {
-    state.sharpeningEnabled = sharpenChk.checked;
-    state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
-    saveUIConfig();
+  const { wrapper: guardDiv } = createCheckboxOption({
+    id: 'chk-guard',
+    checked: state.guardExport,
+    label: 'Coupon auto-redeem before sending commands',
+    onChange: checked => {
+      state.guardExport = checked;
+      state.uiConfig.guardExport = state.guardExport;
+      saveUIConfig();
+    }
   });
-  const sharpenLabel = document.createElement('label');
-  sharpenLabel.htmlFor = 'chk-sharpen';
-  sharpenLabel.textContent = 'Enable sharpen filter';
-  sharpenDiv.appendChild(sharpenChk);
-  sharpenDiv.appendChild(sharpenLabel);
-
-  const guardDiv = document.createElement('div');
-  guardDiv.style.marginTop = '8px';
-  const guardChk = document.createElement('input');
-  guardChk.type = 'checkbox';
-  guardChk.id = 'chk-guard';
-  guardChk.checked = state.guard_Export;
-  guardChk.addEventListener('change', () => {
-    state.guard_Export = guardChk.checked;
-    state.uiConfig.guardExport = state.guard_Export;
-    localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
-    console.log('[Reward Redeemer] Guard export set to', state.guard_Export);
-  });
-  const guardLabel = document.createElement('label');
-  guardLabel.htmlFor = 'chk-guard';
-  guardLabel.textContent = 'Coupon auto-redeem before sending commands';
-  guardDiv.appendChild(guardChk);
-  guardDiv.appendChild(guardLabel);
 
   panel.appendChild(autosendDiv);
   panel.appendChild(guardDiv);
@@ -406,52 +385,6 @@ export function toggleExtraConfigPanel() {
   const panel = document.getElementById('extra-config-panel');
   if (!panel) return;
   panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-}
-
-export function createConfigPanel() {
-  if (document.getElementById('config-panel')) return;
-  const panel = document.createElement('div');
-  panel.id = 'config-panel';
-  panel.style.cssText = `
-    position: fixed;
-    top: 60px;
-    left: 60px;
-    background: #fff;
-    padding: 12px;
-    border: 1px solid #000;
-    border-radius: 6px;
-    z-index: 10002;
-    display: none;
-    color: black;
-    font-size: 15px;
-    font-weight: bold;
-    line-height: 1.6em;
-  `;
-  panel.innerHTML = `
-    <label>Size: <input id="cfg-size" type="number" value="${state.size}" /></label><br/>
-    <label>Col Clues: <input id="cfg-cols" type="number" value="${state.colClueCount}" /></label><br/>
-    <label>Fine Tune: <input id="cfg-fine" type="number" value="${state.fineTune}" /></label><br/>
-    <label>Anchor X: <input id="cfg-anchorX" type="number" value="${state.anchorX}" /></label><br/>
-    <label>Anchor Y: <input id="cfg-anchorY" type="number" value="${state.anchorY}" /></label><br/>
-    <button id="cfg-apply">Apply</button>
-    <button id="cfg-close">Close</button>
-  `;
-  document.body.appendChild(panel);
-
-  panel.querySelector('#cfg-apply').onclick = () => {
-    state.size = +panel.querySelector('#cfg-size').value;
-    state.colClueCount = +panel.querySelector('#cfg-cols').value;
-    state.fineTune = +panel.querySelector('#cfg-fine').value;
-    state.anchorX = +panel.querySelector('#cfg-anchorX').value;
-    state.anchorY = +panel.querySelector('#cfg-anchorY').value;
-    saveLayout();
-    initCells();
-    updateCanvasSizeRef();
-  };
-
-  panel.querySelector('#cfg-close').onclick = () => {
-    panel.style.display = 'none';
-  };
 }
 
 export function createStatusContainer() {
@@ -495,9 +428,8 @@ export function createStatusContainer() {
       let cmd = cmds[idx] || '';
       if (!cmd) return;
       if (state.statusAltCmd) cmd = cmd + 's';
-      console.log(`[StatusCanvas] clicked index=${idx}, sending ${cmd}`);
       try {
-        send_message_with_event(cmd);
+        sendMessageWithEvent(cmd);
         state.statusAltCmd = !state.statusAltCmd;
       } catch (e) {
         console.error('Failed to send status command:', e);

--- a/src/status-controls.js
+++ b/src/status-controls.js
@@ -1,0 +1,518 @@
+// Builds the side controls, extra settings panel, and clickable status preview canvases.
+import { saveLayout, saveUIConfig, state, statusRegions } from './state.js';
+import {
+  decrementCols,
+  decrementFineTune,
+  decrementSize,
+  exportDartCommand,
+  incrementCols,
+  incrementFineTune,
+  incrementSize,
+  initCells,
+  resetSizeDefaults
+} from './nonogram-grid.js';
+import { ensureProgressLoop, ensureSendLoop, send_message_with_event, stopProgressLoop } from './twitch-chat.js';
+
+let updateCanvasSizeRef;
+let createGridRef;
+let minimizeCanvasRef;
+
+export function configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas }) {
+  updateCanvasSizeRef = updateCanvasSize;
+  createGridRef = createGrid;
+  minimizeCanvasRef = minimizeCanvas;
+}
+
+export function createControlPanel() {
+  const controlContainer = document.createElement('div');
+  controlContainer.id = 'control-container';
+  Object.assign(controlContainer.style, {
+    position: 'absolute',
+    right: '-160px',
+    top: '0',
+    zIndex: '10001',
+    padding: '8px',
+    background: '#fff',
+    border: '1px solid #000',
+    borderRadius: '4px',
+    boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
+    lineHeight: '1.4em',
+    color: 'black',
+    width: '160px'
+  });
+
+  state.frame.appendChild(controlContainer);
+
+  state.labelMap = {};
+  state.controlSections = [
+    { key: 'size', label: 'Grid size', get: () => state.size, dec: decrementSize, inc: incrementSize },
+    { key: 'cols', label: 'Col clues', get: () => state.colClueCount, dec: decrementCols, inc: incrementCols },
+    { key: 'fine', label: 'Fine tune', get: () => state.fineTune, dec: decrementFineTune, inc: incrementFineTune }
+  ];
+
+  state.controlSections.forEach((s, i) => {
+    const sec = document.createElement('div');
+    sec.id = `section-${s.key}`;
+    if (s.key === 'fine' && !state.fineTuningEnabled) {
+      sec.style.display = 'none';
+    }
+
+    const lbl = document.createElement('div');
+    lbl.textContent = `${s.label}: ${s.get()}`;
+    state.labelMap[s.key] = lbl;
+    lbl.style.fontWeight = 'bold';
+    lbl.style.marginBottom = '4px';
+    sec.appendChild(lbl);
+
+    const row = document.createElement('div');
+    Object.assign(row.style, {
+      display: 'flex',
+      gap: '4px',
+      marginBottom: '8px',
+      alignItems: 'center'
+    });
+
+    [['−', s.dec], ['+', s.inc]].forEach(([symbol, fn]) => {
+      const btn = document.createElement('button');
+      btn.textContent = symbol;
+      Object.assign(btn.style, {
+        width: '28px',
+        height: '28px',
+        border: '1px solid #007bff',
+        borderRadius: '4px',
+        fontSize: '16px',
+        cursor: 'pointer',
+        backgroundColor: '#007bff',
+        color: 'white',
+        textAlign: 'center'
+      });
+      btn.addEventListener('click', () => {
+        fn();
+        lbl.textContent = `${s.label}: ${s.get()}`;
+      });
+      row.appendChild(btn);
+    });
+
+    if (s.key === 'size') {
+      const spacer = document.createElement('div');
+      spacer.style.flex = '1';
+      row.appendChild(spacer);
+
+      const resetBtn = document.createElement('button');
+      resetBtn.textContent = '4';
+      Object.assign(resetBtn.style, {
+        width: '28px',
+        height: '28px',
+        border: '1px solid #28a745',
+        borderRadius: '4px',
+        fontSize: '16px',
+        cursor: 'pointer',
+        backgroundColor: '#28a745',
+        color: 'white',
+        textAlign: 'center'
+      });
+      resetBtn.addEventListener('click', () => {
+        resetSizeDefaults();
+        lbl.textContent = `${s.label}: ${s.get()}`;
+      });
+      row.appendChild(resetBtn);
+    }
+
+    if (s.key === 'cols') {
+      const spacer = document.createElement('div');
+      spacer.style.flex = '1';
+      row.appendChild(spacer);
+
+      state.exportDartBtn = document.createElement('button');
+      state.exportDartBtn.textContent = '🎯';
+      Object.assign(state.exportDartBtn.style, {
+        width: '28px',
+        height: '28px',
+        border: '1px solid #D6B1AA',
+        borderRadius: '4px',
+        fontSize: '16px',
+        cursor: 'pointer',
+        backgroundColor: '#FFFFFF',
+        color: 'white',
+        textAlign: 'center'
+      });
+      state.exportDartBtn.addEventListener('click', exportDartCommand);
+      row.appendChild(state.exportDartBtn);
+    }
+
+    sec.appendChild(row);
+    controlContainer.appendChild(sec);
+    if (i < state.controlSections.length - 1) controlContainer.appendChild(document.createElement('hr'));
+  });
+
+  const magSec = document.createElement('div');
+  magSec.id = 'section-zoom';
+
+  const magLbl = document.createElement('div');
+  magLbl.textContent = 'Magnification';
+  magLbl.style.fontWeight = 'bold';
+  magLbl.style.marginBottom = '4px';
+  magSec.appendChild(magLbl);
+
+  const magRow = document.createElement('div');
+  Object.assign(magRow.style, {
+    display: 'flex',
+    gap: '4px',
+    marginBottom: '8px',
+    alignItems: 'center'
+  });
+
+  const makeZoomBtn = (label, onClick) => {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    Object.assign(btn.style, {
+      width: '28px',
+      height: '28px',
+      border: '1px solid #007bff',
+      borderRadius: '4px',
+      fontSize: '16px',
+      cursor: 'pointer',
+      backgroundColor: '#007bff',
+      color: 'white',
+      textAlign: 'center'
+    });
+    btn.addEventListener('click', onClick);
+    return btn;
+  };
+
+  magRow.appendChild(makeZoomBtn('−', () => {
+    state.zoomFactor = Math.max(0.1, state.zoomFactor * 0.9);
+    updateCanvasSizeRef();
+  }));
+  magRow.appendChild(makeZoomBtn('+', () => {
+    state.zoomFactor = state.zoomFactor * 1.1;
+    updateCanvasSizeRef();
+  }));
+
+  magSec.appendChild(magRow);
+  controlContainer.appendChild(magSec);
+}
+
+export function updateAllLabels() {
+  Object.entries(state.labelMap).forEach(([k, lbl]) => {
+    const section = state.controlSections.find(s => s.key === k);
+    if (section) lbl.textContent = `${section.label}: ${section.get()}`;
+  });
+}
+
+export function createExtraConfigPanel() {
+  if (document.getElementById('extra-config-panel')) return;
+
+  const panel = document.createElement('div');
+  panel.id = 'extra-config-panel';
+  panel.style.cssText = `
+    position: absolute;
+    top: 40px;
+    left: 0;
+    background: #f9f9f9;
+    padding: 12px;
+    border: 1px solid #333;
+    border-radius: 6px;
+    z-index: 10002;
+    display: none;
+    color: black;
+    font-size: 14px;
+    width: 200px;
+  `;
+
+  const minDiv = document.createElement('div');
+  const minChk = document.createElement('input');
+  minChk.type = 'checkbox';
+  minChk.id = 'chk-minimize';
+  minChk.checked = state.showMinimizeButtons;
+  minChk.style.marginRight = '6px';
+  minChk.addEventListener('change', () => {
+    state.showMinimizeButtons = minChk.checked;
+    state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
+    saveUIConfig();
+    if (state.showMinimizeButtons) {
+      if (!state.minimizeBtn && !state.isMinimized) {
+        state.minimizeBtn = document.createElement('button');
+        state.minimizeBtn.textContent = 'X';
+        Object.assign(state.minimizeBtn.style, {
+          position: 'absolute',
+          top: '4px',
+          left: '4px',
+          width: '24px',
+          height: '24px',
+          fontWeight: 'bold',
+          fontSize: '16px',
+          lineHeight: '22px',
+          textAlign: 'center',
+          zIndex: 10002,
+          background: '#f0f0f0',
+          border: '1px solid #444',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          padding: '0',
+          color: 'black'
+        });
+        state.minimizeBtn.onclick = minimizeCanvasRef;
+        state.frame.appendChild(state.minimizeBtn);
+      }
+    } else {
+      if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+        state.minimizeBtn.remove();
+        state.minimizeBtn = null;
+      }
+      const restoreBtn = document.getElementById('restore-button');
+      if (restoreBtn) restoreBtn.style.display = 'none';
+    }
+  });
+  const minLabel = document.createElement('label');
+  minLabel.htmlFor = 'chk-minimize';
+  minLabel.textContent = 'Enable minimize/restore';
+  minDiv.appendChild(minChk);
+  minDiv.appendChild(minLabel);
+
+  const blueDiv = document.createElement('div');
+  blueDiv.style.marginTop = '8px';
+  const blueChk = document.createElement('input');
+  blueChk.type = 'checkbox';
+  blueChk.id = 'chk-bluefill';
+  blueChk.checked = state.useBlueFill;
+  blueChk.style.marginRight = '6px';
+  blueChk.addEventListener('change', () => {
+    state.useBlueFill = blueChk.checked;
+    state.uiConfig.useBlueFill = state.useBlueFill;
+    saveUIConfig();
+    createGridRef();
+  });
+  const blueLabel = document.createElement('label');
+  blueLabel.htmlFor = 'chk-bluefill';
+  blueLabel.textContent = 'Use blue fill color';
+  blueDiv.appendChild(blueChk);
+  blueDiv.appendChild(blueLabel);
+
+  const statusDivToggle = document.createElement('div');
+  statusDivToggle.style.marginTop = '8px';
+  const statusChk = document.createElement('input');
+  statusChk.type = 'checkbox';
+  statusChk.id = 'chk-status';
+  statusChk.checked = state.statusEnabled;
+  statusChk.style.marginRight = '6px';
+  statusChk.addEventListener('change', () => {
+    state.statusEnabled = statusChk.checked;
+    state.uiConfig.statusEnabled = state.statusEnabled;
+    saveUIConfig();
+    const scCont = document.getElementById('status-container');
+    if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
+  });
+  const statusLabel = document.createElement('label');
+  statusLabel.htmlFor = 'chk-status';
+  statusLabel.textContent = 'Status canvas';
+  statusDivToggle.appendChild(statusChk);
+  statusDivToggle.appendChild(statusLabel);
+
+  const autosendDiv = document.createElement('div');
+  autosendDiv.style.marginTop = '8px';
+  const autosendChk = document.createElement('input');
+  autosendChk.type = 'checkbox';
+  autosendChk.id = 'chk-autosend';
+  autosendChk.checked = state.autosendEnabled;
+  autosendChk.style.marginRight = '6px';
+  autosendChk.addEventListener('change', () => {
+    state.autosendEnabled = autosendChk.checked;
+    state.uiConfig.autosendEnabled = state.autosendEnabled;
+    saveUIConfig();
+    if (state.autosendEnabled) {
+      ensureSendLoop();
+      ensureProgressLoop();
+    } else {
+      stopProgressLoop();
+    }
+  });
+  const autosendLabel = document.createElement('label');
+  autosendLabel.htmlFor = 'chk-autosend';
+  autosendLabel.textContent = 'Auto-send chat commands';
+  autosendDiv.appendChild(autosendChk);
+  autosendDiv.appendChild(autosendLabel);
+
+  const fineDiv = document.createElement('div');
+  fineDiv.style.marginTop = '8px';
+  const fineChk = document.createElement('input');
+  fineChk.type = 'checkbox';
+  fineChk.id = 'chk-fine';
+  fineChk.checked = state.fineTuningEnabled;
+  fineChk.style.marginRight = '6px';
+  fineChk.addEventListener('change', () => {
+    state.fineTuningEnabled = fineChk.checked;
+    state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
+    saveUIConfig();
+    const fineSection = document.getElementById('section-fine');
+    if (fineSection) {
+      fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+    }
+  });
+  const fineLabel = document.createElement('label');
+  fineLabel.htmlFor = 'chk-fine';
+  fineLabel.textContent = 'Enable fine-tune controls';
+  fineDiv.appendChild(fineChk);
+  fineDiv.appendChild(fineLabel);
+
+  const sharpenDiv = document.createElement('div');
+  sharpenDiv.style.marginTop = '8px';
+  const sharpenChk = document.createElement('input');
+  sharpenChk.type = 'checkbox';
+  sharpenChk.id = 'chk-sharpen';
+  sharpenChk.checked = state.sharpeningEnabled;
+  sharpenChk.style.marginRight = '6px';
+  sharpenChk.addEventListener('change', () => {
+    state.sharpeningEnabled = sharpenChk.checked;
+    state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
+    saveUIConfig();
+  });
+  const sharpenLabel = document.createElement('label');
+  sharpenLabel.htmlFor = 'chk-sharpen';
+  sharpenLabel.textContent = 'Enable sharpen filter';
+  sharpenDiv.appendChild(sharpenChk);
+  sharpenDiv.appendChild(sharpenLabel);
+
+  const guardDiv = document.createElement('div');
+  guardDiv.style.marginTop = '8px';
+  const guardChk = document.createElement('input');
+  guardChk.type = 'checkbox';
+  guardChk.id = 'chk-guard';
+  guardChk.checked = state.guard_Export;
+  guardChk.addEventListener('change', () => {
+    state.guard_Export = guardChk.checked;
+    state.uiConfig.guardExport = state.guard_Export;
+    localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
+    console.log('[Reward Redeemer] Guard export set to', state.guard_Export);
+  });
+  const guardLabel = document.createElement('label');
+  guardLabel.htmlFor = 'chk-guard';
+  guardLabel.textContent = 'Coupon auto-redeem before sending commands';
+  guardDiv.appendChild(guardChk);
+  guardDiv.appendChild(guardLabel);
+
+  panel.appendChild(autosendDiv);
+  panel.appendChild(guardDiv);
+  panel.appendChild(minDiv);
+  panel.appendChild(blueDiv);
+  panel.appendChild(statusDivToggle);
+  panel.appendChild(fineDiv);
+  panel.appendChild(sharpenDiv);
+
+  state.frame.appendChild(panel);
+}
+
+export function toggleExtraConfigPanel() {
+  const panel = document.getElementById('extra-config-panel');
+  if (!panel) return;
+  panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+}
+
+export function createConfigPanel() {
+  if (document.getElementById('config-panel')) return;
+  const panel = document.createElement('div');
+  panel.id = 'config-panel';
+  panel.style.cssText = `
+    position: fixed;
+    top: 60px;
+    left: 60px;
+    background: #fff;
+    padding: 12px;
+    border: 1px solid #000;
+    border-radius: 6px;
+    z-index: 10002;
+    display: none;
+    color: black;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: 1.6em;
+  `;
+  panel.innerHTML = `
+    <label>Size: <input id="cfg-size" type="number" value="${state.size}" /></label><br/>
+    <label>Col Clues: <input id="cfg-cols" type="number" value="${state.colClueCount}" /></label><br/>
+    <label>Fine Tune: <input id="cfg-fine" type="number" value="${state.fineTune}" /></label><br/>
+    <label>Anchor X: <input id="cfg-anchorX" type="number" value="${state.anchorX}" /></label><br/>
+    <label>Anchor Y: <input id="cfg-anchorY" type="number" value="${state.anchorY}" /></label><br/>
+    <button id="cfg-apply">Apply</button>
+    <button id="cfg-close">Close</button>
+  `;
+  document.body.appendChild(panel);
+
+  panel.querySelector('#cfg-apply').onclick = () => {
+    state.size = +panel.querySelector('#cfg-size').value;
+    state.colClueCount = +panel.querySelector('#cfg-cols').value;
+    state.fineTune = +panel.querySelector('#cfg-fine').value;
+    state.anchorX = +panel.querySelector('#cfg-anchorX').value;
+    state.anchorY = +panel.querySelector('#cfg-anchorY').value;
+    saveLayout();
+    initCells();
+    updateCanvasSizeRef();
+  };
+
+  panel.querySelector('#cfg-close').onclick = () => {
+    panel.style.display = 'none';
+  };
+}
+
+export function createStatusContainer() {
+  if (document.getElementById('status-container')) return;
+  const controlContainer = document.getElementById('control-container');
+  if (!controlContainer) return;
+
+  const scCont = document.createElement('div');
+  scCont.id = 'status-container';
+  scCont.style.cssText = `
+    display: none;
+    margin-top: 8px;
+    width: 100%;
+    text-align: center;
+  `;
+
+  const cw = Math.max(40, controlContainer.clientWidth - 20);
+  const ch = Math.round((cw * 80) / 250);
+  const cmds = ['!eat', '!sleep', '!play'];
+
+  state.statusCanvases = [];
+
+  statusRegions.forEach((region, idx) => {
+    const sc = document.createElement('canvas');
+    sc.id = `status-canvas-${idx}`;
+    sc.width = cw;
+    sc.height = ch;
+    sc.style.cssText = `
+      display: inline-block;
+      margin: 4px;
+      width: ${cw}px;
+      height: ${ch}px;
+      border: 1px solid #333;
+      background: black;
+      cursor: pointer;
+      box-sizing: content-box;
+    `;
+
+    const sctx = sc.getContext('2d');
+    sc.addEventListener('click', () => {
+      let cmd = cmds[idx] || '';
+      if (!cmd) return;
+      if (state.statusAltCmd) cmd = cmd + 's';
+      console.log(`[StatusCanvas] clicked index=${idx}, sending ${cmd}`);
+      try {
+        send_message_with_event(cmd);
+        state.statusAltCmd = !state.statusAltCmd;
+      } catch (e) {
+        console.error('Failed to send status command:', e);
+      }
+    });
+
+    scCont.appendChild(sc);
+    state.statusCanvases.push({ canvas: sc, ctx: sctx, region });
+  });
+
+  controlContainer.appendChild(scCont);
+  scCont.style.display = state.statusEnabled ? 'block' : 'none';
+}
+
+export function createControlAndStatus() {
+  createControlPanel();
+  createStatusContainer();
+}

--- a/src/twitch-chat.js
+++ b/src/twitch-chat.js
@@ -1,40 +1,40 @@
 // Integrates with Twitch chat, including message sending and autosend cooldown handling.
 import { state } from './state.js';
 
-export function send_message_with_event(message) {
-  if (!state.current_chat || !state.current_chat.props?.onSendMessage) {
-    state.current_chat = get_current_chat();
+export function sendMessageWithEvent(message) {
+  if (!state.currentChat || !state.currentChat.props?.onSendMessage) {
+    state.currentChat = getCurrentChat();
   }
 
-  if (state.current_chat?.props?.onSendMessage) {
-    state.current_chat.props.onSendMessage(message);
+  if (state.currentChat?.props?.onSendMessage) {
+    state.currentChat.props.onSendMessage(message);
   } else {
     console.error('Chat not available or missing onSendMessage. (Are you on a chat page and logged in?)');
   }
 }
 
-export function get_current_chat() {
+export function getCurrentChat() {
   try {
-    const chat_node = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
-    if (!chat_node) return null;
+    const chatNode = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
+    if (!chatNode) return null;
 
-    const react_instance = get_react_instance(chat_node);
-    if (!react_instance) return null;
+    const reactInstance = getReactInstance(chatNode);
+    if (!reactInstance) return null;
 
-    const chat_component = search_react_parents(
-      react_instance,
+    const chatComponent = searchReactParents(
+      reactInstance,
       node => node.stateNode && node.stateNode.props && node.stateNode.props.onSendMessage
     );
 
-    return chat_component ? chat_component.stateNode : null;
+    return chatComponent ? chatComponent.stateNode : null;
   } catch (e) {
     console.error('Error accessing chat:', e);
     return null;
   }
 }
 
-function get_react_instance(el) {
-  for (const k in el) {
+function getReactInstance(el) {
+  for (const k of Object.keys(el)) {
     if (k.startsWith('__reactInternalInstance$') || k.startsWith('__reactFiber$')) {
       return el[k];
     }
@@ -42,12 +42,12 @@ function get_react_instance(el) {
   return null;
 }
 
-function search_react_parents(node, predicate, max_depth = 15, depth = 0) {
-  if (!node || depth > max_depth) return null;
+function searchReactParents(node, predicate, maxDepth = 15, depth = 0) {
+  if (!node || depth > maxDepth) return null;
   try {
     if (predicate(node)) return node;
   } catch {}
-  return search_react_parents(node.return, predicate, max_depth, depth + 1);
+  return searchReactParents(node.return, predicate, maxDepth, depth + 1);
 }
 
 export function scheduleSend(msg) {
@@ -63,7 +63,7 @@ export function ensureSendLoop() {
     if (state.sendQueue.length > 0 && now >= state.nextSendAt) {
       const next = state.sendQueue.shift();
       try {
-        send_message_with_event(next);
+        sendMessageWithEvent(next);
       } catch (e) {
         console.error(e);
       }
@@ -93,14 +93,14 @@ export function stopProgressLoop() {
 function cooldownProgress01() {
   const now = Date.now();
   if (now < state.nextSendAt) return 1 - (state.nextSendAt - now) / state.COOLDOWN_MS;
-  if (state.sendQueue.length > 0) return 1;
   return 1;
 }
 
 export function updateCooldownUI() {
   if (!state.autosendEnabled || (!state.exportFillBtn && !state.exportEmptyBtn)) return;
+  const now = Date.now();
   const p = cooldownProgress01();
-  const ready = Date.now() >= state.nextSendAt && state.sendQueue.length === 0;
+  const ready = now >= state.nextSendAt && state.sendQueue.length === 0;
   [state.exportFillBtn, state.exportEmptyBtn, state.exportDartBtn].forEach(btn => {
     if (!btn) return;
     btn.disabled = !ready;
@@ -110,13 +110,13 @@ export function updateCooldownUI() {
   setBtnProgress(state.exportFillBtn, p);
   setBtnProgress(state.exportEmptyBtn, p);
 
-  const remain = Math.max(0, state.nextSendAt - Date.now());
+  const remain = Math.max(0, state.nextSendAt - now);
   const seconds = Math.ceil(remain / 1000);
   const title = remain > 0 ? `Cooldown: ${seconds}s` : (state.sendQueue.length ? `Queued: ${state.sendQueue.length}` : 'Ready');
   if (state.exportFillBtn) state.exportFillBtn.title = title;
   if (state.exportEmptyBtn) state.exportEmptyBtn.title = title;
 
-  if (!state.autosendEnabled || (state.sendQueue.length === 0 && Date.now() >= state.nextSendAt)) {
+  if (!state.autosendEnabled || (state.sendQueue.length === 0 && now >= state.nextSendAt)) {
     stopProgressLoop();
   }
 }

--- a/src/twitch-chat.js
+++ b/src/twitch-chat.js
@@ -1,0 +1,132 @@
+// Integrates with Twitch chat, including message sending and autosend cooldown handling.
+import { state } from './state.js';
+
+export function send_message_with_event(message) {
+  if (!state.current_chat || !state.current_chat.props?.onSendMessage) {
+    state.current_chat = get_current_chat();
+  }
+
+  if (state.current_chat?.props?.onSendMessage) {
+    state.current_chat.props.onSendMessage(message);
+  } else {
+    console.error('Chat not available or missing onSendMessage. (Are you on a chat page and logged in?)');
+  }
+}
+
+export function get_current_chat() {
+  try {
+    const chat_node = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
+    if (!chat_node) return null;
+
+    const react_instance = get_react_instance(chat_node);
+    if (!react_instance) return null;
+
+    const chat_component = search_react_parents(
+      react_instance,
+      node => node.stateNode && node.stateNode.props && node.stateNode.props.onSendMessage
+    );
+
+    return chat_component ? chat_component.stateNode : null;
+  } catch (e) {
+    console.error('Error accessing chat:', e);
+    return null;
+  }
+}
+
+function get_react_instance(el) {
+  for (const k in el) {
+    if (k.startsWith('__reactInternalInstance$') || k.startsWith('__reactFiber$')) {
+      return el[k];
+    }
+  }
+  return null;
+}
+
+function search_react_parents(node, predicate, max_depth = 15, depth = 0) {
+  if (!node || depth > max_depth) return null;
+  try {
+    if (predicate(node)) return node;
+  } catch {}
+  return search_react_parents(node.return, predicate, max_depth, depth + 1);
+}
+
+export function scheduleSend(msg) {
+  state.sendQueue.push(msg);
+  ensureSendLoop();
+  ensureProgressLoop();
+}
+
+export function ensureSendLoop() {
+  if (state.sendLoopTimer) return;
+  state.sendLoopTimer = setInterval(() => {
+    const now = Date.now();
+    if (state.sendQueue.length > 0 && now >= state.nextSendAt) {
+      const next = state.sendQueue.shift();
+      try {
+        send_message_with_event(next);
+      } catch (e) {
+        console.error(e);
+      }
+      state.nextSendAt = now + state.COOLDOWN_MS;
+    }
+    if (state.sendQueue.length === 0 && now >= state.nextSendAt) {
+      clearInterval(state.sendLoopTimer);
+      state.sendLoopTimer = null;
+    }
+  }, 250);
+}
+
+export function ensureProgressLoop() {
+  if (state.progressTimer) return;
+  state.progressTimer = setInterval(updateCooldownUI, 100);
+}
+
+export function stopProgressLoop() {
+  if (state.progressTimer) {
+    clearInterval(state.progressTimer);
+    state.progressTimer = null;
+  }
+  setBtnProgress(state.exportFillBtn, null);
+  setBtnProgress(state.exportEmptyBtn, null);
+}
+
+function cooldownProgress01() {
+  const now = Date.now();
+  if (now < state.nextSendAt) return 1 - (state.nextSendAt - now) / state.COOLDOWN_MS;
+  if (state.sendQueue.length > 0) return 1;
+  return 1;
+}
+
+export function updateCooldownUI() {
+  if (!state.autosendEnabled || (!state.exportFillBtn && !state.exportEmptyBtn)) return;
+  const p = cooldownProgress01();
+  const ready = Date.now() >= state.nextSendAt && state.sendQueue.length === 0;
+  [state.exportFillBtn, state.exportEmptyBtn, state.exportDartBtn].forEach(btn => {
+    if (!btn) return;
+    btn.disabled = !ready;
+    btn.style.opacity = ready ? '1' : '0.7';
+    btn.style.cursor = ready ? 'pointer' : 'not-allowed';
+  });
+  setBtnProgress(state.exportFillBtn, p);
+  setBtnProgress(state.exportEmptyBtn, p);
+
+  const remain = Math.max(0, state.nextSendAt - Date.now());
+  const seconds = Math.ceil(remain / 1000);
+  const title = remain > 0 ? `Cooldown: ${seconds}s` : (state.sendQueue.length ? `Queued: ${state.sendQueue.length}` : 'Ready');
+  if (state.exportFillBtn) state.exportFillBtn.title = title;
+  if (state.exportEmptyBtn) state.exportEmptyBtn.title = title;
+
+  if (!state.autosendEnabled || (state.sendQueue.length === 0 && Date.now() >= state.nextSendAt)) {
+    stopProgressLoop();
+  }
+}
+
+function setBtnProgress(btn, p) {
+  if (!btn) return;
+  if (p == null) {
+    btn.style.backgroundImage = '';
+    return;
+  }
+  const pct = Math.max(0, Math.min(1, p)) * 100;
+  btn.style.backgroundImage = `linear-gradient(to right, rgba(0,200,0,0.35) ${pct}%, transparent ${pct}%)`;
+}

--- a/src/twitch-redeem.js
+++ b/src/twitch-redeem.js
@@ -48,6 +48,28 @@ export async function redeemAndTrack(onUpdateActivityButton) {
   }
 }
 
+export function scheduleAutoRedeem() {
+  if (state.autoRedeemTimer) {
+    clearTimeout(state.autoRedeemTimer);
+    state.autoRedeemTimer = null;
+  }
+
+  const delay = (40 + Math.random() * 15) * 60000;
+  console.log(`[Reward Redeemer] Next auto redeem in ${(delay / 60000).toFixed(1)} min`);
+
+  state.autoRedeemTimer = setTimeout(async () => {
+    await redeemAndTrack();
+    scheduleAutoRedeem();
+  }, delay);
+}
+
+export function cancelAutoRedeem() {
+  if (state.autoRedeemTimer) {
+    clearTimeout(state.autoRedeemTimer);
+    state.autoRedeemTimer = null;
+  }
+}
+
 export async function guardedExport(fn, ...args) {
   if (!state.guardExport) {
     return fn(...args);

--- a/src/twitch-redeem.js
+++ b/src/twitch-redeem.js
@@ -40,7 +40,6 @@ export async function redeemAndTrack(onUpdateActivityButton) {
           onUpdateActivityButton();
         } catch {}
       }
-      scheduleAutoRedeem(onUpdateActivityButton);
     } else {
       console.log('[Reward Redeemer] Redeem attempt did not complete (timed out or no button).');
     }
@@ -49,24 +48,8 @@ export async function redeemAndTrack(onUpdateActivityButton) {
   }
 }
 
-export function scheduleAutoRedeem(onUpdateActivityButton) {
-  if (!state.autoRedeemEnabled) return;
-  if (state.autoRedeemTimer) {
-    clearTimeout(state.autoRedeemTimer);
-    state.autoRedeemTimer = null;
-  }
-
-  const delay = (40 + Math.random() * 15) * 60000;
-  console.log(`[Reward Redeemer] Next auto redeem in ${(delay / 60000).toFixed(1)} min`);
-
-  state.autoRedeemTimer = setTimeout(async () => {
-    await redeemAndTrack(onUpdateActivityButton);
-    scheduleAutoRedeem(onUpdateActivityButton);
-  }, delay);
-}
-
 export async function guardedExport(fn, ...args) {
-  if (!state.guard_Export) {
+  if (!state.guardExport) {
     return fn(...args);
   }
 
@@ -155,25 +138,19 @@ function pollAndClickConfirm() {
 }
 
 export async function attemptRedeemCycle() {
-  if (state.busy) return false;
-  state.busy = true;
-  try {
-    const opened = openPanel();
-    if (!opened) return false;
+  const opened = openPanel();
+  if (!opened) return false;
 
-    const rewardPanel = await waitForAnySelector(
-      ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
-      PANEL_WAIT_TIMEOUT
-    );
-    if (!rewardPanel) return false;
+  const rewardPanel = await waitForAnySelector(
+    ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
+    PANEL_WAIT_TIMEOUT
+  );
+  if (!rewardPanel) return false;
 
-    const firstClicked = clickFirstLayerInPanel();
-    if (!firstClicked) return false;
+  const firstClicked = clickFirstLayerInPanel();
+  if (!firstClicked) return false;
 
-    await new Promise(resolve => setTimeout(resolve, 400));
-    const confirmed = await pollAndClickConfirm();
-    return !!confirmed;
-  } finally {
-    state.busy = false;
-  }
+  await new Promise(resolve => setTimeout(resolve, 400));
+  const confirmed = await pollAndClickConfirm();
+  return !!confirmed;
 }

--- a/src/twitch-redeem.js
+++ b/src/twitch-redeem.js
@@ -1,0 +1,179 @@
+// Handles Twitch reward redemption, redeem timing, and guarded export behavior.
+import { state } from './state.js';
+
+const TARGET_REWARD_NAME = 'Activity Coupon';
+const PANEL_WAIT_TIMEOUT = 800;
+const CONFIRM_POLL_INTERVAL = 300;
+const CONFIRM_MAX_ATTEMPTS = 30;
+
+export function setLastRedeem(ts = Date.now()) {
+  try {
+    localStorage.setItem(state.REDEEM_KEY, String(ts));
+  } catch (e) {
+    console.warn('[Reward Redeemer] setLastRedeem failed:', e);
+  }
+}
+
+export function getLastRedeem() {
+  const v = parseInt(localStorage.getItem(state.REDEEM_KEY) || '0', 10);
+  return Number.isFinite(v) ? v : 0;
+}
+
+export function minutesSinceRedeem() {
+  return (Date.now() - getLastRedeem()) / 60000;
+}
+
+export async function redeemAndTrack(onUpdateActivityButton) {
+  if (state.redeemBusy) {
+    console.log('[Reward Redeemer] Another redeem is in progress — skipping.');
+    return;
+  }
+  state.redeemBusy = true;
+  try {
+    console.log('[Reward Redeemer] Redeeming reward...');
+    const success = await attemptRedeemCycle();
+    if (success) {
+      setLastRedeem();
+      state.lastGuardRedeem = Date.now();
+      if (typeof onUpdateActivityButton === 'function') {
+        try {
+          onUpdateActivityButton();
+        } catch {}
+      }
+      scheduleAutoRedeem(onUpdateActivityButton);
+    } else {
+      console.log('[Reward Redeemer] Redeem attempt did not complete (timed out or no button).');
+    }
+  } finally {
+    state.redeemBusy = false;
+  }
+}
+
+export function scheduleAutoRedeem(onUpdateActivityButton) {
+  if (!state.autoRedeemEnabled) return;
+  if (state.autoRedeemTimer) {
+    clearTimeout(state.autoRedeemTimer);
+    state.autoRedeemTimer = null;
+  }
+
+  const delay = (40 + Math.random() * 15) * 60000;
+  console.log(`[Reward Redeemer] Next auto redeem in ${(delay / 60000).toFixed(1)} min`);
+
+  state.autoRedeemTimer = setTimeout(async () => {
+    await redeemAndTrack(onUpdateActivityButton);
+    scheduleAutoRedeem(onUpdateActivityButton);
+  }, delay);
+}
+
+export async function guardedExport(fn, ...args) {
+  if (!state.guard_Export) {
+    return fn(...args);
+  }
+
+  const minutes = minutesSinceRedeem();
+  const now = Date.now();
+
+  if (minutes > 55) {
+    if (now - state.lastGuardRedeem < 60_000) {
+      console.log('[Reward Redeemer] Guarded export skipped — redeem already attempted recently.');
+      return;
+    }
+
+    console.log('[Reward Redeemer] Guarded export requires redeem...');
+    state.lastGuardRedeem = now;
+    await redeemAndTrack();
+  }
+
+  return fn(...args);
+}
+
+function findPanelButton() {
+  return document.querySelector('button[aria-label="Bits and Points Balances"]') ||
+    document.querySelector('[data-test-selector="community-points-summary"] button') ||
+    document.querySelector('button[data-test-selector="community-points-summary-button"]');
+}
+
+function openPanel() {
+  const btn = findPanelButton();
+  if (!btn) return false;
+  btn.click();
+  return true;
+}
+
+function waitForAnySelector(selectors, timeout = 3000) {
+  const start = Date.now();
+  return new Promise(resolve => {
+    const tick = () => {
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el) return resolve(el);
+      }
+      if (Date.now() - start >= timeout) return resolve(null);
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
+function clickFirstLayerInPanel() {
+  const img = document.querySelector(`img[alt="${TARGET_REWARD_NAME}"]`);
+  if (img) {
+    const button = img.closest('button');
+    if (button) {
+      button.click();
+      return true;
+    }
+  }
+  return false;
+}
+
+function pollAndClickConfirm() {
+  return new Promise(resolve => {
+    let attempts = 0;
+    const poll = setInterval(() => {
+      attempts++;
+      const confirmButton = document.querySelector('button:has(p[data-test-selector="RewardText"])');
+
+      if (confirmButton) {
+        const ariaAncestor = confirmButton.closest('[aria-hidden]');
+        if (!ariaAncestor || ariaAncestor.getAttribute('aria-hidden') !== 'true') {
+          try {
+            confirmButton.click();
+          } catch {}
+          clearInterval(poll);
+          resolve(true);
+          return;
+        }
+      }
+
+      if (attempts >= CONFIRM_MAX_ATTEMPTS) {
+        clearInterval(poll);
+        resolve(false);
+      }
+    }, CONFIRM_POLL_INTERVAL);
+  });
+}
+
+export async function attemptRedeemCycle() {
+  if (state.busy) return false;
+  state.busy = true;
+  try {
+    const opened = openPanel();
+    if (!opened) return false;
+
+    const rewardPanel = await waitForAnySelector(
+      ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
+      PANEL_WAIT_TIMEOUT
+    );
+    if (!rewardPanel) return false;
+
+    const firstClicked = clickFirstLayerInPanel();
+    if (!firstClicked) return false;
+
+    await new Promise(resolve => setTimeout(resolve, 400));
+    const confirmed = await pollAndClickConfirm();
+    return !!confirmed;
+  } finally {
+    state.busy = false;
+  }
+}

--- a/src/userscript/banner.js
+++ b/src/userscript/banner.js
@@ -1,0 +1,11 @@
+// ==UserScript==
+// @name         Twitch Nonogram Grid with canvas
+// @namespace    http://tampermonkey.net/
+// @version      4.40
+// @description  Nonogram overlay + status bars + persistent config
+// @author       mrpantera+menels+86maylin+a lot of chatgpt + kurotaku codes
+// @match        https://www.twitch.tv/goki*
+// @grant        none
+// @run-at       document-start
+// @downloadURL  https://menels10.github.io/nonogram-twitch-overlay/twitch-nonogram-canvas.user.js
+// ==/UserScript==

--- a/src/userscript/main.js
+++ b/src/userscript/main.js
@@ -1,0 +1,4 @@
+// Userscript entrypoint that starts the modular app after bundling.
+import { bootstrap } from '../app.js';
+
+bootstrap();

--- a/twitch-nonogram-canvas.user.js
+++ b/twitch-nonogram-canvas.user.js
@@ -38,7 +38,6 @@
     roiHeightPercent: 0.584,
     configs: {},
     autosendEnabled: false,
-    videoEl: null,
     canvas: null,
     ctx: null,
     frame: null,
@@ -1535,12 +1534,7 @@
   }
 
   function getVideoElement() {
-    if (state.videoEl?.isConnected && state.videoEl.readyState >= 2) {
-      return state.videoEl;
-    }
-
-    state.videoEl = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
-    return state.videoEl;
+    return [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
   }
 
   function sharpen(ctx, w, h, mix) {

--- a/twitch-nonogram-canvas.user.js
+++ b/twitch-nonogram-canvas.user.js
@@ -42,6 +42,7 @@
     canvas: null,
     ctx: null,
     frame: null,
+    buttonContainer: null,
     isDragging: false,
     dragOffsetX: 0,
     dragOffsetY: 0,
@@ -54,6 +55,7 @@
     markValue: 0,
     eraseMode: false,
     isMinimized: false,
+    isPaused: false,
     renderHandle: null,
     minimizeBtn: null,
     moveHistory: [],
@@ -80,6 +82,7 @@
     labelMap: {},
     controlSections: [],
     roiInterval: null,
+    autoRedeemTimer: null,
     documentMouseMoveHandler: null,
     documentMouseUpHandler: null
   };
@@ -1598,7 +1601,7 @@
 
   function updateROI() {
     const video = getVideoElement();
-    if (!video) return;
+    if (!video || state.isPaused) return;
 
     state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
 
@@ -1819,6 +1822,7 @@
     border-top: 1px solid #333;
   `;
     state.frame.appendChild(container);
+    state.buttonContainer = container;
 
     const makeBtn = (label, onClick) => {
       const btn = document.createElement('button');
@@ -1954,6 +1958,7 @@
     state.progressTimer = null;
     state.sendLoopTimer = null;
     state.roiInterval = null;
+    state.buttonContainer = null;
     state.documentMouseMoveHandler = null;
     state.documentMouseUpHandler = null;
   }

--- a/twitch-nonogram-canvas.user.js
+++ b/twitch-nonogram-canvas.user.js
@@ -13,8 +13,7 @@
   'use strict';
 
   // Holds shared runtime state, persistent config, and layout constants used across modules.
-  const state = {
-    uiConfig: JSON.parse(localStorage.getItem('nonogramUIConfig')) || {
+  const DEFAULT_UI_CONFIG = {
       showMinimizeButtons: false,
       useBlueFill: false,
       statusEnabled: false,
@@ -22,22 +21,24 @@
       sharpeningEnabled: false,
       autosendEnabled: false,
       guardExport: false
-    },
-    roiCanvas: document.createElement('canvas'),
+    };
+
+  const state = {
+    uiConfig: { ...DEFAULT_UI_CONFIG },
+    roiCanvas: null,
     roiCtx: null,
     DEFAULT_CONF: { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 },
     size: 4,
-    rowClueCount: 1,
     colClueCount: 1,
-    ratio: 1.0,
     anchorX: 10,
     anchorY: 10,
     zoomFactor: 1.4,
     fineTune: 0,
     roiWidthPercent: 0.36,
     roiHeightPercent: 0.584,
-    configs: JSON.parse(localStorage.getItem('nonogramConfigMap')) || {},
+    configs: {},
     autosendEnabled: false,
+    videoEl: null,
     canvas: null,
     ctx: null,
     frame: null,
@@ -57,6 +58,7 @@
     minimizeBtn: null,
     moveHistory: [],
     currentAction: null,
+    geometryCache: null,
     lastDartExportIndex: 1,
     COOLDOWN_MS: 10_000,
     nextSendAt: 0,
@@ -69,17 +71,12 @@
     statusAltCmd: false,
     rowDashes: [],
     colDashes: [],
-    redeemBtn: null,
     lastGuardRedeem: 0,
     REDEEM_KEY: 'lastRedeemTimestamp',
-    redeemButtonMonitorId: null,
     activityBtnMonitorId: null,
     redeemBusy: false,
-    autoRedeemEnabled: false,
-    autoRedeemTimer: null,
-    busy: false,
     statusCanvases: [],
-    current_chat: null,
+    currentChat: null,
     labelMap: {},
     controlSections: [],
     roiInterval: null,
@@ -87,22 +84,29 @@
     documentMouseUpHandler: null
   };
 
-  if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
-    state.uiConfig.sharpeningEnabled = false;
-  }
+  function initState() {
+    const storedUIConfig = JSON.parse(localStorage.getItem('nonogramUIConfig') || 'null') || {};
+    state.uiConfig = { ...DEFAULT_UI_CONFIG, ...storedUIConfig };
 
-  state.roiCtx = state.roiCanvas.getContext('2d');
-  state.anchorX = state.DEFAULT_CONF.anchorX;
-  state.anchorY = state.DEFAULT_CONF.anchorY;
-  state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
-  state.fineTune = state.DEFAULT_CONF.fineTune;
-  state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
-  state.useBlueFill = state.uiConfig.useBlueFill;
-  state.statusEnabled = state.uiConfig.statusEnabled;
-  state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
-  state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
-  state.guard_Export = state.uiConfig.guardExport;
-  state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
+    if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
+      state.uiConfig.sharpeningEnabled = false;
+    }
+
+    state.configs = JSON.parse(localStorage.getItem('nonogramConfigMap') || 'null') || {};
+    state.roiCanvas = document.createElement('canvas');
+    state.roiCtx = state.roiCanvas.getContext('2d');
+    state.anchorX = state.DEFAULT_CONF.anchorX;
+    state.anchorY = state.DEFAULT_CONF.anchorY;
+    state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
+    state.fineTune = state.DEFAULT_CONF.fineTune;
+    state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
+    state.useBlueFill = state.uiConfig.useBlueFill;
+    state.statusEnabled = state.uiConfig.statusEnabled;
+    state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
+    state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
+    state.guardExport = state.uiConfig.guardExport;
+    state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
+  }
 
   function saveUIConfig() {
     localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
@@ -223,8 +227,8 @@
     { sx: 800, sy: 980, sw: 250, sh: 70 }
   ];
 
-  function getKey(sz, rc, cc) {
-    return `${sz}x${rc}x${cc}`;
+  function getKey(sz, cc) {
+    return `${sz}x${cc}`;
   }
 
   function getLayoutSettings(size, colClueLength) {
@@ -242,14 +246,12 @@
   }
 
   function saveLayout() {
-    const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+    const key = getKey(state.size, state.colClueCount);
     state.configs[key] = {
-      ratio: state.ratio,
       anchorX: state.anchorX,
       anchorY: state.anchorY,
       fineTune: state.fineTune,
       size: state.size,
-      rowClueCount: state.rowClueCount,
       colClueCount: state.colClueCount
     };
     localStorage.setItem('nonogramConfigMap', JSON.stringify(state.configs));
@@ -261,7 +263,7 @@
       state.anchorX = layout.anchorX;
       state.anchorY = layout.anchorY;
     }
-    const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+    const key = getKey(state.size, state.colClueCount);
     const saved = state.configs[key];
     if (saved) {
       state.fineTune = saved.fineTune ?? state.fineTune;
@@ -280,40 +282,40 @@
 
   // Integrates with Twitch chat, including message sending and autosend cooldown handling.
 
-  function send_message_with_event(message) {
-    if (!state.current_chat || !state.current_chat.props?.onSendMessage) {
-      state.current_chat = get_current_chat();
+  function sendMessageWithEvent(message) {
+    if (!state.currentChat || !state.currentChat.props?.onSendMessage) {
+      state.currentChat = getCurrentChat();
     }
 
-    if (state.current_chat?.props?.onSendMessage) {
-      state.current_chat.props.onSendMessage(message);
+    if (state.currentChat?.props?.onSendMessage) {
+      state.currentChat.props.onSendMessage(message);
     } else {
       console.error('Chat not available or missing onSendMessage. (Are you on a chat page and logged in?)');
     }
   }
 
-  function get_current_chat() {
+  function getCurrentChat() {
     try {
-      const chat_node = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
-      if (!chat_node) return null;
+      const chatNode = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
+      if (!chatNode) return null;
 
-      const react_instance = get_react_instance(chat_node);
-      if (!react_instance) return null;
+      const reactInstance = getReactInstance(chatNode);
+      if (!reactInstance) return null;
 
-      const chat_component = search_react_parents(
-        react_instance,
+      const chatComponent = searchReactParents(
+        reactInstance,
         node => node.stateNode && node.stateNode.props && node.stateNode.props.onSendMessage
       );
 
-      return chat_component ? chat_component.stateNode : null;
+      return chatComponent ? chatComponent.stateNode : null;
     } catch (e) {
       console.error('Error accessing chat:', e);
       return null;
     }
   }
 
-  function get_react_instance(el) {
-    for (const k in el) {
+  function getReactInstance(el) {
+    for (const k of Object.keys(el)) {
       if (k.startsWith('__reactInternalInstance$') || k.startsWith('__reactFiber$')) {
         return el[k];
       }
@@ -321,12 +323,12 @@
     return null;
   }
 
-  function search_react_parents(node, predicate, max_depth = 15, depth = 0) {
-    if (!node || depth > max_depth) return null;
+  function searchReactParents(node, predicate, maxDepth = 15, depth = 0) {
+    if (!node || depth > maxDepth) return null;
     try {
       if (predicate(node)) return node;
     } catch {}
-    return search_react_parents(node.return, predicate, max_depth, depth + 1);
+    return searchReactParents(node.return, predicate, maxDepth, depth + 1);
   }
 
   function scheduleSend(msg) {
@@ -342,7 +344,7 @@
       if (state.sendQueue.length > 0 && now >= state.nextSendAt) {
         const next = state.sendQueue.shift();
         try {
-          send_message_with_event(next);
+          sendMessageWithEvent(next);
         } catch (e) {
           console.error(e);
         }
@@ -372,14 +374,14 @@
   function cooldownProgress01() {
     const now = Date.now();
     if (now < state.nextSendAt) return 1 - (state.nextSendAt - now) / state.COOLDOWN_MS;
-    if (state.sendQueue.length > 0) return 1;
     return 1;
   }
 
   function updateCooldownUI() {
     if (!state.autosendEnabled || (!state.exportFillBtn && !state.exportEmptyBtn)) return;
+    const now = Date.now();
     const p = cooldownProgress01();
-    const ready = Date.now() >= state.nextSendAt && state.sendQueue.length === 0;
+    const ready = now >= state.nextSendAt && state.sendQueue.length === 0;
     [state.exportFillBtn, state.exportEmptyBtn, state.exportDartBtn].forEach(btn => {
       if (!btn) return;
       btn.disabled = !ready;
@@ -389,13 +391,13 @@
     setBtnProgress(state.exportFillBtn, p);
     setBtnProgress(state.exportEmptyBtn, p);
 
-    const remain = Math.max(0, state.nextSendAt - Date.now());
+    const remain = Math.max(0, state.nextSendAt - now);
     const seconds = Math.ceil(remain / 1000);
     const title = remain > 0 ? `Cooldown: ${seconds}s` : (state.sendQueue.length ? `Queued: ${state.sendQueue.length}` : 'Ready');
     if (state.exportFillBtn) state.exportFillBtn.title = title;
     if (state.exportEmptyBtn) state.exportEmptyBtn.title = title;
 
-    if (!state.autosendEnabled || (state.sendQueue.length === 0 && Date.now() >= state.nextSendAt)) {
+    if (!state.autosendEnabled || (state.sendQueue.length === 0 && now >= state.nextSendAt)) {
       stopProgressLoop();
     }
   }
@@ -451,7 +453,6 @@
             onUpdateActivityButton();
           } catch {}
         }
-        scheduleAutoRedeem(onUpdateActivityButton);
       } else {
         console.log('[Reward Redeemer] Redeem attempt did not complete (timed out or no button).');
       }
@@ -460,12 +461,8 @@
     }
   }
 
-  function scheduleAutoRedeem(onUpdateActivityButton) {
-    return;
-  }
-
   async function guardedExport(fn, ...args) {
-    if (!state.guard_Export) {
+    if (!state.guardExport) {
       return fn(...args);
     }
 
@@ -554,41 +551,54 @@
   }
 
   async function attemptRedeemCycle() {
-    if (state.busy) return false;
-    state.busy = true;
-    try {
-      const opened = openPanel();
-      if (!opened) return false;
+    const opened = openPanel();
+    if (!opened) return false;
 
-      const rewardPanel = await waitForAnySelector(
-        ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
-        PANEL_WAIT_TIMEOUT
-      );
-      if (!rewardPanel) return false;
+    const rewardPanel = await waitForAnySelector(
+      ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
+      PANEL_WAIT_TIMEOUT
+    );
+    if (!rewardPanel) return false;
 
-      const firstClicked = clickFirstLayerInPanel();
-      if (!firstClicked) return false;
+    const firstClicked = clickFirstLayerInPanel();
+    if (!firstClicked) return false;
 
-      await new Promise(resolve => setTimeout(resolve, 400));
-      const confirmed = await pollAndClickConfirm();
-      return !!confirmed;
-    } finally {
-      state.busy = false;
-    }
+    await new Promise(resolve => setTimeout(resolve, 400));
+    const confirmed = await pollAndClickConfirm();
+    return !!confirmed;
   }
 
   // Owns nonogram state, geometry, drawing, exports, and canvas interaction logic.
 
   let updateCanvasSizeRef$1;
 
+  const COL_LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+  const CELL_EMPTY = 0;
+  const CELL_FILLED = 1;
+  const CELL_MARKED = 2;
+
+  function colLetter(index) {
+    return COL_LETTERS[index];
+  }
+
+  function safeClipboardWrite(text) {
+    try {
+      navigator.clipboard.writeText(text);
+    } catch (error) {
+      console.warn('Clipboard write failed:', error);
+      alert(text);
+    }
+  }
+
   function configureNonogramGrid({ updateCanvasSize }) {
     updateCanvasSizeRef$1 = updateCanvasSize;
   }
 
   function initCells() {
-    state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(0));
+    state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(CELL_EMPTY));
     state.lastExported = new Set();
     state.lastExportedWhite = new Set();
+    state.geometryCache = null;
     resetClueDashes();
   }
 
@@ -598,20 +608,17 @@
 
   async function exportDartCommand() {
     let msg = '!darts';
-    for (let i = 0; i < msg.length; i++) {
-      if (i === state.lastDartExportIndex) {
-        msg = msg.substring(0, i) + msg[i].toUpperCase() + msg.substring(i + 1);
-        state.lastDartExportIndex++;
-        if (state.lastDartExportIndex >= msg.length) {
-          state.lastDartExportIndex = 1;
-        }
-        break;
-      }
+    const chars = [...msg];
+    chars[state.lastDartExportIndex] = chars[state.lastDartExportIndex].toUpperCase();
+    msg = chars.join('');
+    state.lastDartExportIndex++;
+    if (state.lastDartExportIndex >= msg.length) {
+      state.lastDartExportIndex = 1;
     }
     if (state.autosendEnabled) {
       scheduleSend(msg);
     } else {
-      navigator.clipboard.writeText(msg);
+      safeClipboardWrite(msg);
     }
   }
 
@@ -658,8 +665,22 @@
   }
 
   function computeGridGeometry() {
+    const cacheKey = [
+      state.size,
+      state.colClueCount,
+      state.fineTune,
+      state.anchorX,
+      state.anchorY,
+      state.canvas?.width,
+      state.canvas?.height
+    ].join(':');
+
+    if (state.geometryCache?.key === cacheKey) {
+      return state.geometryCache.value;
+    }
+
     state.ctx.font = 'bold 30px Arial';
-    const clueW = state.ctx.measureText('0'.repeat(state.rowClueCount)).width;
+    const clueW = state.ctx.measureText('0').width;
     const clueH = 30 * state.colClueCount + 5;
 
     const layout = getLayoutSettings(state.size, state.colClueCount);
@@ -675,7 +696,9 @@
     const ox = state.canvas.width - cellSize * state.size - state.anchorX;
     const oy = state.canvas.height - cellSize * state.size - state.anchorY;
 
-    return { clueW, clueH, cellSize, ox, oy };
+    const geometry = { clueW, clueH, cellSize, ox, oy };
+    state.geometryCache = { key: cacheKey, value: geometry };
+    return geometry;
   }
 
   function resetClueDashes() {
@@ -695,23 +718,23 @@
     const coords = [];
     state.cellStates.forEach((row, r) => {
       row.forEach((s, c) => {
-        if (s === 1) {
-          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-          if (!state.lastExported.has(coord)) {
-            coords.push(coord);
-            state.lastExported.add(coord);
+          if (s === 1) {
+            const coord = `${colLetter(c)}${r + 1}`;
+            if (!state.lastExported.has(coord)) {
+              coords.push(coord);
+              state.lastExported.add(coord);
           }
         }
       });
     });
-    if (coords.length) {
-      const msg = `!fill ${coords.join(' ')}`;
-      if (state.autosendEnabled) {
-        scheduleSend(msg);
-      } else {
-        navigator.clipboard.writeText(msg);
+      if (coords.length) {
+        const msg = `!fill ${coords.join(' ')}`;
+        if (state.autosendEnabled) {
+          scheduleSend(msg);
+        } else {
+          safeClipboardWrite(msg);
+        }
       }
-    }
   }
 
   function exportAllCellsInner(mode) {
@@ -725,7 +748,7 @@
       state.cellStates.forEach((row, r) => {
         row.forEach((s, c) => {
           if (s === 1) {
-            const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+            const coord = `${colLetter(c)}${r + 1}`;
             coords.push(coord);
             state.lastExported.add(coord);
           }
@@ -733,14 +756,14 @@
       });
       if (coords.length) {
         const msg = `!fill ${coords.join(' ')}`;
-        navigator.clipboard.writeText(msg);
         if (state.autosendEnabled) scheduleSend(msg);
+        else safeClipboardWrite(msg);
       }
     } else if (mode === 'white') {
       state.cellStates.forEach((row, r) => {
         row.forEach((s, c) => {
-          if (s === 2) {
-            const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          if (s === CELL_MARKED) {
+            const coord = `${colLetter(c)}${r + 1}`;
             coords.push(coord);
             state.lastExportedWhite.add(coord);
           }
@@ -748,8 +771,8 @@
       });
       if (coords.length) {
         const msg = `!empty ${coords.join(' ')}`;
-        navigator.clipboard.writeText(msg);
         if (state.autosendEnabled) scheduleSend(msg);
+        else safeClipboardWrite(msg);
       }
     }
   }
@@ -759,7 +782,7 @@
     state.cellStates.forEach((row, r) => {
       row.forEach((s, c) => {
         if (s === 2) {
-          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          const coord = `${colLetter(c)}${r + 1}`;
           if (!state.lastExportedWhite.has(coord)) {
             coords.push(coord);
             state.lastExportedWhite.add(coord);
@@ -772,7 +795,7 @@
       if (state.autosendEnabled) {
         scheduleSend(msg);
       } else {
-        navigator.clipboard.writeText(msg);
+        safeClipboardWrite(msg);
       }
     }
   }
@@ -790,19 +813,13 @@
   }
 
   function exportClearCommand() {
-    const letters = 'abcdefghijklmnopqrstuvwxyz';
     const ranges = [];
     for (let c = 0; c < state.size; c++) {
-      const col = letters[c];
+      const col = colLetter(c);
       ranges.push(`${col}1-${col}${state.size}`);
     }
     const clearCmd = `!clear ${ranges.join(',')}`;
-    try {
-      navigator.clipboard.writeText(clearCmd);
-    } catch (e) {
-      console.warn('Clipboard write failed:', e);
-      alert(clearCmd);
-    }
+    safeClipboardWrite(clearCmd);
   }
 
   function createGrid() {
@@ -857,21 +874,24 @@
       }
     }
 
+    const filledColor = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
+    const markedColor = 'rgba(255, 255, 255, 0.6)';
+
     for (let r = 0; r < state.size; r++) {
       for (let c = 0; c < state.size; c++) {
         const x = ox + c * cellSize;
         const y = oy + r * cellSize;
 
-        if (state.cellStates[r][c] === 1) {
-          state.ctx.fillStyle = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
-        } else if (state.cellStates[r][c] === 2) {
-          state.ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+        if (state.cellStates[r][c] === CELL_FILLED) {
+          state.ctx.fillStyle = filledColor;
+        } else if (state.cellStates[r][c] === CELL_MARKED) {
+          state.ctx.fillStyle = markedColor;
         }
 
         state.ctx.strokeRect(x, y, cellSize, cellSize);
-        if (state.cellStates[r][c] === 1 || state.cellStates[r][c] === 2) {
+        if (state.cellStates[r][c] === CELL_FILLED || state.cellStates[r][c] === CELL_MARKED) {
           state.ctx.fillRect(x, y, cellSize, cellSize);
-          if (state.cellStates[r][c] === 2) state.ctx.fillStyle = 'black';
+          if (state.cellStates[r][c] === CELL_MARKED) state.ctx.fillStyle = 'black';
         }
       }
     }
@@ -917,11 +937,11 @@
 
     if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
       state.isMarking = true;
-      state.markValue = e.button === 0 ? 1 : 2;
+      state.markValue = e.button === 0 ? CELL_FILLED : CELL_MARKED;
       state.eraseMode = state.cellStates[r][c] === state.markValue;
 
       const prevValue = state.cellStates[r][c];
-      const newValue = state.eraseMode ? 0 : state.markValue;
+      const newValue = state.eraseMode ? CELL_EMPTY : state.markValue;
       state.cellStates[r][c] = newValue;
       state.currentAction = [{ row: r, col: c, previous: prevValue, newValue }];
       createGrid();
@@ -963,11 +983,13 @@
       newCol = c;
     }
 
+    const hoverChanged = newRow !== state.hoveredRow || newCol !== state.hoveredCol;
     state.hoveredRow = newRow;
     state.hoveredCol = newCol;
 
+    let cellChanged = false;
     if (state.isMarking && newRow >= 0 && newCol >= 0) {
-      const targetValue = state.eraseMode ? 0 : state.markValue;
+      const targetValue = state.eraseMode ? CELL_EMPTY : state.markValue;
       if (state.cellStates[newRow][newCol] !== targetValue) {
         if (!state.currentAction) state.currentAction = [];
         state.currentAction.push({
@@ -977,19 +999,22 @@
           newValue: targetValue
         });
         state.cellStates[newRow][newCol] = targetValue;
+        cellChanged = true;
       }
     }
 
-    createGrid();
+    if (hoverChanged || cellChanged) {
+      createGrid();
+    }
   }
 
   function undoLastAction() {
     if (!state.moveHistory.length) return;
     const lastAction = state.moveHistory.pop();
     lastAction.forEach(({ row, col, previous, newValue }) => {
-      const coord = `${String.fromCharCode(97 + col)}${row + 1}`;
-      if (newValue === 1) state.lastExported.delete(coord);
-      if (newValue === 2) state.lastExportedWhite.delete(coord);
+      const coord = `${colLetter(col)}${row + 1}`;
+      if (newValue === CELL_FILLED) state.lastExported.delete(coord);
+      if (newValue === CELL_MARKED) state.lastExportedWhite.delete(coord);
       state.cellStates[row][col] = previous;
     });
     createGrid();
@@ -1025,12 +1050,14 @@
 
   function decrementFineTune() {
     state.fineTune--;
+    state.geometryCache = null;
     saveLayout();
     updateCanvasSizeRef$1();
   }
 
   function incrementFineTune() {
     state.fineTune++;
+    state.geometryCache = null;
     saveLayout();
     updateCanvasSizeRef$1();
   }
@@ -1038,13 +1065,59 @@
   function resetSizeDefaults() {
     saveLayout();
     state.size = 4;
-    state.rowClueCount = 1;
     state.colClueCount = 1;
     initCells();
     updateCanvasSizeRef$1();
   }
 
   // Builds the side controls, extra settings panel, and clickable status preview canvases.
+
+  const MINIMIZE_BUTTON_STYLE$1 = {
+    position: 'absolute',
+    top: '4px',
+    left: '4px',
+    width: '24px',
+    height: '24px',
+    fontWeight: 'bold',
+    fontSize: '16px',
+    lineHeight: '22px',
+    textAlign: 'center',
+    zIndex: 10002,
+    background: '#f0f0f0',
+    border: '1px solid #444',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    padding: '0',
+    color: 'black'
+  };
+
+  function createCheckboxOption({ id, checked, label, onChange, marginTop = '8px' }) {
+    const wrapper = document.createElement('div');
+    wrapper.style.marginTop = marginTop;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = id;
+    checkbox.checked = checked;
+    checkbox.style.marginRight = '6px';
+    checkbox.addEventListener('change', () => onChange(checkbox.checked));
+
+    const labelElement = document.createElement('label');
+    labelElement.htmlFor = id;
+    labelElement.textContent = label;
+
+    wrapper.appendChild(checkbox);
+    wrapper.appendChild(labelElement);
+    return { wrapper, checkbox };
+  }
+
+  function createMinimizeButton$1(onClick) {
+    const button = document.createElement('button');
+    button.textContent = 'X';
+    Object.assign(button.style, MINIMIZE_BUTTON_STYLE$1);
+    button.onclick = onClick;
+    return button;
+  }
 
   let updateCanvasSizeRef;
   let createGridRef;
@@ -1246,176 +1319,109 @@
     width: 200px;
   `;
 
-    const minDiv = document.createElement('div');
-    const minChk = document.createElement('input');
-    minChk.type = 'checkbox';
-    minChk.id = 'chk-minimize';
-    minChk.checked = state.showMinimizeButtons;
-    minChk.style.marginRight = '6px';
-    minChk.addEventListener('change', () => {
-      state.showMinimizeButtons = minChk.checked;
-      state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
-      saveUIConfig();
-      if (state.showMinimizeButtons) {
-        if (!state.minimizeBtn && !state.isMinimized) {
-          state.minimizeBtn = document.createElement('button');
-          state.minimizeBtn.textContent = 'X';
-          Object.assign(state.minimizeBtn.style, {
-            position: 'absolute',
-            top: '4px',
-            left: '4px',
-            width: '24px',
-            height: '24px',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            textAlign: 'center',
-            zIndex: 10002,
-            background: '#f0f0f0',
-            border: '1px solid #444',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            padding: '0',
-            color: 'black'
-          });
-          state.minimizeBtn.onclick = minimizeCanvasRef;
-          state.frame.appendChild(state.minimizeBtn);
+    const { wrapper: minDiv } = createCheckboxOption({
+      id: 'chk-minimize',
+      checked: state.showMinimizeButtons,
+      label: 'Enable minimize/restore',
+      marginTop: '0',
+      onChange: checked => {
+        state.showMinimizeButtons = checked;
+        state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
+        saveUIConfig();
+        if (state.showMinimizeButtons) {
+          if (!state.minimizeBtn && !state.isMinimized) {
+            state.minimizeBtn = createMinimizeButton$1(minimizeCanvasRef);
+            state.frame.appendChild(state.minimizeBtn);
+          }
+        } else {
+          if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+            state.minimizeBtn.remove();
+            state.minimizeBtn = null;
+          }
+          const restoreBtn = document.getElementById('restore-button');
+          if (restoreBtn) restoreBtn.style.display = 'none';
         }
-      } else {
-        if (state.minimizeBtn && state.minimizeBtn.parentElement) {
-          state.minimizeBtn.remove();
-          state.minimizeBtn = null;
+      }
+    });
+
+    const { wrapper: blueDiv } = createCheckboxOption({
+      id: 'chk-bluefill',
+      checked: state.useBlueFill,
+      label: 'Use blue fill color',
+      onChange: checked => {
+        state.useBlueFill = checked;
+        state.uiConfig.useBlueFill = state.useBlueFill;
+        saveUIConfig();
+        createGridRef();
+      }
+    });
+
+    const { wrapper: statusDivToggle } = createCheckboxOption({
+      id: 'chk-status',
+      checked: state.statusEnabled,
+      label: 'Status canvas',
+      onChange: checked => {
+        state.statusEnabled = checked;
+        state.uiConfig.statusEnabled = state.statusEnabled;
+        saveUIConfig();
+        const scCont = document.getElementById('status-container');
+        if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
+      }
+    });
+
+    const { wrapper: autosendDiv } = createCheckboxOption({
+      id: 'chk-autosend',
+      checked: state.autosendEnabled,
+      label: 'Auto-send chat commands',
+      onChange: checked => {
+        state.autosendEnabled = checked;
+        state.uiConfig.autosendEnabled = state.autosendEnabled;
+        saveUIConfig();
+        if (state.autosendEnabled) {
+          ensureSendLoop();
+          ensureProgressLoop();
+        } else {
+          stopProgressLoop();
         }
-        const restoreBtn = document.getElementById('restore-button');
-        if (restoreBtn) restoreBtn.style.display = 'none';
       }
     });
-    const minLabel = document.createElement('label');
-    minLabel.htmlFor = 'chk-minimize';
-    minLabel.textContent = 'Enable minimize/restore';
-    minDiv.appendChild(minChk);
-    minDiv.appendChild(minLabel);
 
-    const blueDiv = document.createElement('div');
-    blueDiv.style.marginTop = '8px';
-    const blueChk = document.createElement('input');
-    blueChk.type = 'checkbox';
-    blueChk.id = 'chk-bluefill';
-    blueChk.checked = state.useBlueFill;
-    blueChk.style.marginRight = '6px';
-    blueChk.addEventListener('change', () => {
-      state.useBlueFill = blueChk.checked;
-      state.uiConfig.useBlueFill = state.useBlueFill;
-      saveUIConfig();
-      createGridRef();
-    });
-    const blueLabel = document.createElement('label');
-    blueLabel.htmlFor = 'chk-bluefill';
-    blueLabel.textContent = 'Use blue fill color';
-    blueDiv.appendChild(blueChk);
-    blueDiv.appendChild(blueLabel);
-
-    const statusDivToggle = document.createElement('div');
-    statusDivToggle.style.marginTop = '8px';
-    const statusChk = document.createElement('input');
-    statusChk.type = 'checkbox';
-    statusChk.id = 'chk-status';
-    statusChk.checked = state.statusEnabled;
-    statusChk.style.marginRight = '6px';
-    statusChk.addEventListener('change', () => {
-      state.statusEnabled = statusChk.checked;
-      state.uiConfig.statusEnabled = state.statusEnabled;
-      saveUIConfig();
-      const scCont = document.getElementById('status-container');
-      if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
-    });
-    const statusLabel = document.createElement('label');
-    statusLabel.htmlFor = 'chk-status';
-    statusLabel.textContent = 'Status canvas';
-    statusDivToggle.appendChild(statusChk);
-    statusDivToggle.appendChild(statusLabel);
-
-    const autosendDiv = document.createElement('div');
-    autosendDiv.style.marginTop = '8px';
-    const autosendChk = document.createElement('input');
-    autosendChk.type = 'checkbox';
-    autosendChk.id = 'chk-autosend';
-    autosendChk.checked = state.autosendEnabled;
-    autosendChk.style.marginRight = '6px';
-    autosendChk.addEventListener('change', () => {
-      state.autosendEnabled = autosendChk.checked;
-      state.uiConfig.autosendEnabled = state.autosendEnabled;
-      saveUIConfig();
-      if (state.autosendEnabled) {
-        ensureSendLoop();
-        ensureProgressLoop();
-      } else {
-        stopProgressLoop();
+    const { wrapper: fineDiv } = createCheckboxOption({
+      id: 'chk-fine',
+      checked: state.fineTuningEnabled,
+      label: 'Enable fine-tune controls',
+      onChange: checked => {
+        state.fineTuningEnabled = checked;
+        state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
+        saveUIConfig();
+        const fineSection = document.getElementById('section-fine');
+        if (fineSection) {
+          fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+        }
       }
     });
-    const autosendLabel = document.createElement('label');
-    autosendLabel.htmlFor = 'chk-autosend';
-    autosendLabel.textContent = 'Auto-send chat commands';
-    autosendDiv.appendChild(autosendChk);
-    autosendDiv.appendChild(autosendLabel);
 
-    const fineDiv = document.createElement('div');
-    fineDiv.style.marginTop = '8px';
-    const fineChk = document.createElement('input');
-    fineChk.type = 'checkbox';
-    fineChk.id = 'chk-fine';
-    fineChk.checked = state.fineTuningEnabled;
-    fineChk.style.marginRight = '6px';
-    fineChk.addEventListener('change', () => {
-      state.fineTuningEnabled = fineChk.checked;
-      state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
-      saveUIConfig();
-      const fineSection = document.getElementById('section-fine');
-      if (fineSection) {
-        fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+    const { wrapper: sharpenDiv } = createCheckboxOption({
+      id: 'chk-sharpen',
+      checked: state.sharpeningEnabled,
+      label: 'Enable sharpen filter',
+      onChange: checked => {
+        state.sharpeningEnabled = checked;
+        state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
+        saveUIConfig();
       }
     });
-    const fineLabel = document.createElement('label');
-    fineLabel.htmlFor = 'chk-fine';
-    fineLabel.textContent = 'Enable fine-tune controls';
-    fineDiv.appendChild(fineChk);
-    fineDiv.appendChild(fineLabel);
 
-    const sharpenDiv = document.createElement('div');
-    sharpenDiv.style.marginTop = '8px';
-    const sharpenChk = document.createElement('input');
-    sharpenChk.type = 'checkbox';
-    sharpenChk.id = 'chk-sharpen';
-    sharpenChk.checked = state.sharpeningEnabled;
-    sharpenChk.style.marginRight = '6px';
-    sharpenChk.addEventListener('change', () => {
-      state.sharpeningEnabled = sharpenChk.checked;
-      state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
-      saveUIConfig();
+    const { wrapper: guardDiv } = createCheckboxOption({
+      id: 'chk-guard',
+      checked: state.guardExport,
+      label: 'Coupon auto-redeem before sending commands',
+      onChange: checked => {
+        state.guardExport = checked;
+        state.uiConfig.guardExport = state.guardExport;
+        saveUIConfig();
+      }
     });
-    const sharpenLabel = document.createElement('label');
-    sharpenLabel.htmlFor = 'chk-sharpen';
-    sharpenLabel.textContent = 'Enable sharpen filter';
-    sharpenDiv.appendChild(sharpenChk);
-    sharpenDiv.appendChild(sharpenLabel);
-
-    const guardDiv = document.createElement('div');
-    guardDiv.style.marginTop = '8px';
-    const guardChk = document.createElement('input');
-    guardChk.type = 'checkbox';
-    guardChk.id = 'chk-guard';
-    guardChk.checked = state.guard_Export;
-    guardChk.addEventListener('change', () => {
-      state.guard_Export = guardChk.checked;
-      state.uiConfig.guardExport = state.guard_Export;
-      localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
-      console.log('[Reward Redeemer] Guard export set to', state.guard_Export);
-    });
-    const guardLabel = document.createElement('label');
-    guardLabel.htmlFor = 'chk-guard';
-    guardLabel.textContent = 'Coupon auto-redeem before sending commands';
-    guardDiv.appendChild(guardChk);
-    guardDiv.appendChild(guardLabel);
 
     panel.appendChild(autosendDiv);
     panel.appendChild(guardDiv);
@@ -1432,52 +1438,6 @@
     const panel = document.getElementById('extra-config-panel');
     if (!panel) return;
     panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-  }
-
-  function createConfigPanel() {
-    if (document.getElementById('config-panel')) return;
-    const panel = document.createElement('div');
-    panel.id = 'config-panel';
-    panel.style.cssText = `
-    position: fixed;
-    top: 60px;
-    left: 60px;
-    background: #fff;
-    padding: 12px;
-    border: 1px solid #000;
-    border-radius: 6px;
-    z-index: 10002;
-    display: none;
-    color: black;
-    font-size: 15px;
-    font-weight: bold;
-    line-height: 1.6em;
-  `;
-    panel.innerHTML = `
-    <label>Size: <input id="cfg-size" type="number" value="${state.size}" /></label><br/>
-    <label>Col Clues: <input id="cfg-cols" type="number" value="${state.colClueCount}" /></label><br/>
-    <label>Fine Tune: <input id="cfg-fine" type="number" value="${state.fineTune}" /></label><br/>
-    <label>Anchor X: <input id="cfg-anchorX" type="number" value="${state.anchorX}" /></label><br/>
-    <label>Anchor Y: <input id="cfg-anchorY" type="number" value="${state.anchorY}" /></label><br/>
-    <button id="cfg-apply">Apply</button>
-    <button id="cfg-close">Close</button>
-  `;
-    document.body.appendChild(panel);
-
-    panel.querySelector('#cfg-apply').onclick = () => {
-      state.size = +panel.querySelector('#cfg-size').value;
-      state.colClueCount = +panel.querySelector('#cfg-cols').value;
-      state.fineTune = +panel.querySelector('#cfg-fine').value;
-      state.anchorX = +panel.querySelector('#cfg-anchorX').value;
-      state.anchorY = +panel.querySelector('#cfg-anchorY').value;
-      saveLayout();
-      initCells();
-      updateCanvasSizeRef();
-    };
-
-    panel.querySelector('#cfg-close').onclick = () => {
-      panel.style.display = 'none';
-    };
   }
 
   function createStatusContainer() {
@@ -1521,9 +1481,8 @@
         let cmd = cmds[idx] || '';
         if (!cmd) return;
         if (state.statusAltCmd) cmd = cmd + 's';
-        console.log(`[StatusCanvas] clicked index=${idx}, sending ${cmd}`);
         try {
-          send_message_with_event(cmd);
+          sendMessageWithEvent(cmd);
           state.statusAltCmd = !state.statusAltCmd;
         } catch (e) {
           console.error('Failed to send status command:', e);
@@ -1544,6 +1503,42 @@
   }
 
   // Manages the overlay frame, canvas rendering, ROI capture, and main action buttons.
+
+  const MINIMIZE_BUTTON_STYLE = {
+    position: 'absolute',
+    top: '4px',
+    left: '4px',
+    width: '24px',
+    height: '24px',
+    fontWeight: 'bold',
+    fontSize: '16px',
+    lineHeight: '22px',
+    textAlign: 'center',
+    zIndex: 10002,
+    background: '#f0f0f0',
+    border: '1px solid #444',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    padding: '0',
+    color: 'black'
+  };
+
+  function createMinimizeButton(onClick) {
+    const button = document.createElement('button');
+    button.textContent = 'X';
+    Object.assign(button.style, MINIMIZE_BUTTON_STYLE);
+    button.onclick = onClick;
+    return button;
+  }
+
+  function getVideoElement() {
+    if (state.videoEl?.isConnected && state.videoEl.readyState >= 2) {
+      return state.videoEl;
+    }
+
+    state.videoEl = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2) || null;
+    return state.videoEl;
+  }
 
   function sharpen(ctx, w, h, mix) {
     let x;
@@ -1602,7 +1597,7 @@
   }
 
   function updateROI() {
-    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    const video = getVideoElement();
     if (!video) return;
 
     state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
@@ -1622,7 +1617,7 @@
   }
 
   function drawStatus() {
-    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    const video = getVideoElement();
     if (!video) return;
 
     const actualWidth = video.videoWidth;
@@ -1671,9 +1666,6 @@
     const btns = document.getElementById('button-container');
     if (btns) btns.style.display = 'none';
 
-    const cfg = document.getElementById('config-panel');
-    if (cfg) cfg.style.display = 'none';
-
     const extraCfg = document.getElementById('extra-config-panel');
     if (extraCfg) extraCfg.style.display = 'none';
 
@@ -1711,27 +1703,7 @@
     if (statusCont) statusCont.style.display = state.statusEnabled ? 'block' : 'none';
 
     if (state.showMinimizeButtons && !state.minimizeBtn) {
-      state.minimizeBtn = document.createElement('button');
-      state.minimizeBtn.textContent = 'X';
-      Object.assign(state.minimizeBtn.style, {
-        position: 'absolute',
-        top: '4px',
-        left: '4px',
-        width: '24px',
-        height: '24px',
-        fontWeight: 'bold',
-        fontSize: '16px',
-        lineHeight: '22px',
-        textAlign: 'center',
-        zIndex: 10002,
-        background: '#f0f0f0',
-        border: '1px solid #444',
-        borderRadius: '4px',
-        cursor: 'pointer',
-        padding: '0',
-        color: 'black'
-      });
-      state.minimizeBtn.onclick = minimizeCanvas;
+      state.minimizeBtn = createMinimizeButton(minimizeCanvas);
       state.frame.appendChild(state.minimizeBtn);
     }
   }
@@ -1769,7 +1741,7 @@
     });
     restoreBtn.onclick = () => restoreCanvas();
 
-    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    const video = getVideoElement();
     if (video && video.parentElement) {
       video.parentElement.style.position = 'relative';
       video.parentElement.appendChild(restoreBtn);
@@ -1778,27 +1750,7 @@
     }
 
     if (state.showMinimizeButtons) {
-      state.minimizeBtn = document.createElement('button');
-      state.minimizeBtn.textContent = 'X';
-      Object.assign(state.minimizeBtn.style, {
-        position: 'absolute',
-        top: '4px',
-        left: '4px',
-        width: '24px',
-        height: '24px',
-        fontWeight: 'bold',
-        fontSize: '16px',
-        lineHeight: '22px',
-        textAlign: 'center',
-        zIndex: 10002,
-        background: '#f0f0f0',
-        border: '1px solid #444',
-        borderRadius: '4px',
-        cursor: 'pointer',
-        padding: '0',
-        color: 'black'
-      });
-      state.minimizeBtn.onclick = minimizeCanvas;
+      state.minimizeBtn = createMinimizeButton(minimizeCanvas);
       state.frame.appendChild(state.minimizeBtn);
     }
 
@@ -1968,10 +1920,23 @@
 
   // Bootstraps the userscript, wires the grouped modules together, and handles cleanup.
 
-  configureNonogramGrid({ updateCanvasSize });
-  configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+  const readyCallbacks = [];
+  const shutdownCallbacks = [];
+  let hasBootstrapped = false;
+
+  function notifyCallbacks(callbacks) {
+    callbacks.forEach(callback => {
+      try {
+        callback();
+      } catch (error) {
+        console.error('Lifecycle callback failed:', error);
+      }
+    });
+  }
 
   function cleanup() {
+    notifyCallbacks(shutdownCallbacks);
+
     if (state.activityBtnMonitorId) clearInterval(state.activityBtnMonitorId);
     if (state.progressTimer) clearInterval(state.progressTimer);
     if (state.sendLoopTimer) clearInterval(state.sendLoopTimer);
@@ -1984,14 +1949,27 @@
     if (state.documentMouseUpHandler) {
       document.removeEventListener('mouseup', state.documentMouseUpHandler);
     }
+
+    state.activityBtnMonitorId = null;
+    state.progressTimer = null;
+    state.sendLoopTimer = null;
+    state.roiInterval = null;
+    state.documentMouseMoveHandler = null;
+    state.documentMouseUpHandler = null;
   }
 
   function onLoad() {
+    if (hasBootstrapped) return;
+    hasBootstrapped = true;
+
+    initState();
+    configureNonogramGrid({ updateCanvasSize });
+    configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+
     setupCanvas();
     initCells();
     updateCanvasSize();
     createMainButtons();
-    createConfigPanel();
     createControlAndStatus();
     createExtraConfigPanel();
     if (state.autosendEnabled) {
@@ -2000,11 +1978,17 @@
     }
     render();
     state.roiInterval = setInterval(updateROI, 1000);
+    notifyCallbacks(readyCallbacks);
   }
 
   function bootstrap() {
     window.addEventListener('beforeunload', cleanup);
-    window.addEventListener('load', onLoad);
+    if (document.readyState === 'complete') {
+      onLoad();
+      return;
+    }
+
+    window.addEventListener('load', onLoad, { once: true });
   }
 
   // Userscript entrypoint that starts the modular app after bundling.

--- a/twitch-nonogram-canvas.user.js
+++ b/twitch-nonogram-canvas.user.js
@@ -9,1972 +9,1478 @@
 // @run-at       document-start
 // @downloadURL  https://menels10.github.io/nonogram-twitch-overlay/twitch-nonogram-canvas.user.js
 // ==/UserScript==
-
 (function () {
-    'use strict';
+  'use strict';
 
-    //
-    // ─── PERSISTENT UI CONFIG ─────────────────────────────────────────────────────
-    //
-    let uiConfig = JSON.parse(localStorage.getItem('nonogramUIConfig')) || {
-        showMinimizeButtons: false,
-        useBlueFill:         false,
-        statusEnabled:       false,
-        fineTuningEnabled:   false,
-        sharpeningEnabled:   false,
-        autosendEnabled:     false,
-        guardExport:         false
-    };
-    if (typeof uiConfig.sharpeningEnabled !== 'boolean') {
-        uiConfig.sharpeningEnabled = false;
-    }
-    function saveUIConfig() {
-        localStorage.setItem('nonogramUIConfig', JSON.stringify(uiConfig));
-    }
+  // Holds shared runtime state, persistent config, and layout constants used across modules.
+  const state = {
+    uiConfig: JSON.parse(localStorage.getItem('nonogramUIConfig')) || {
+      showMinimizeButtons: false,
+      useBlueFill: false,
+      statusEnabled: false,
+      fineTuningEnabled: false,
+      sharpeningEnabled: false,
+      autosendEnabled: false,
+      guardExport: false
+    },
+    roiCanvas: document.createElement('canvas'),
+    roiCtx: null,
+    DEFAULT_CONF: { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 },
+    size: 4,
+    rowClueCount: 1,
+    colClueCount: 1,
+    ratio: 1.0,
+    anchorX: 10,
+    anchorY: 10,
+    zoomFactor: 1.4,
+    fineTune: 0,
+    roiWidthPercent: 0.36,
+    roiHeightPercent: 0.584,
+    configs: JSON.parse(localStorage.getItem('nonogramConfigMap')) || {},
+    autosendEnabled: false,
+    canvas: null,
+    ctx: null,
+    frame: null,
+    isDragging: false,
+    dragOffsetX: 0,
+    dragOffsetY: 0,
+    lastExported: new Set(),
+    lastExportedWhite: new Set(),
+    cellStates: [],
+    hoveredRow: -1,
+    hoveredCol: -1,
+    isMarking: false,
+    markValue: 0,
+    eraseMode: false,
+    isMinimized: false,
+    renderHandle: null,
+    minimizeBtn: null,
+    moveHistory: [],
+    currentAction: null,
+    lastDartExportIndex: 1,
+    COOLDOWN_MS: 10_000,
+    nextSendAt: 0,
+    sendQueue: [],
+    sendLoopTimer: null,
+    progressTimer: null,
+    exportFillBtn: null,
+    exportEmptyBtn: null,
+    exportDartBtn: null,
+    statusAltCmd: false,
+    rowDashes: [],
+    colDashes: [],
+    redeemBtn: null,
+    lastGuardRedeem: 0,
+    REDEEM_KEY: 'lastRedeemTimestamp',
+    redeemButtonMonitorId: null,
+    activityBtnMonitorId: null,
+    redeemBusy: false,
+    autoRedeemEnabled: false,
+    autoRedeemTimer: null,
+    busy: false,
+    statusCanvases: [],
+    current_chat: null,
+    labelMap: {},
+    controlSections: [],
+    roiInterval: null,
+    documentMouseMoveHandler: null,
+    documentMouseUpHandler: null
+  };
 
-    //
-    // ─── MUTABLE FLAGS (initial values from uiConfig) ─────────────────────────────
-    //
-    let showMinimizeButtons  = uiConfig.showMinimizeButtons;
-    let useBlueFill          = uiConfig.useBlueFill;
-    let statusEnabled        = uiConfig.statusEnabled;
-    let fineTuningEnabled    = uiConfig.fineTuningEnabled;
-    let sharpeningEnabled = uiConfig.sharpeningEnabled;
-    let guard_Export = uiConfig.guardExport;
-    let roiCanvas = document.createElement('canvas');
-    let roiCtx = roiCanvas.getContext('2d');
-    const DEFAULT_CONF = { anchorX: 10, anchorY: 10, zoomFactor: 1.4, fineTune: 0 };
-    let size = 4, rowClueCount = 1, colClueCount = 1, ratio = 1.0;
-    let anchorX = DEFAULT_CONF.anchorX, anchorY = DEFAULT_CONF.anchorY;
-    let zoomFactor = DEFAULT_CONF.zoomFactor, fineTune = DEFAULT_CONF.fineTune;
-    let roiWidthPercent = 0.36, roiHeightPercent = 0.584;
-    let configs = JSON.parse(localStorage.getItem('nonogramConfigMap')) || {};
-    let autosendEnabled = uiConfig.autosendEnabled ?? false;
-    let canvas, ctx, frame;
-    let isDragging = false, dragOffsetX = 0, dragOffsetY = 0;
-    let lastExported = new Set(), lastExportedWhite = new Set(), cellStates = [];
-    let hoveredRow = -1, hoveredCol = -1;
-    let isMarking = false, markValue = 0, eraseMode = false;
-    let isMinimized = false, renderHandle = null;
-    let minimizeBtn;
-    let moveHistory = [], currentAction = null;
-    let lastDartExportIndex = 1;
-    // ===== Autosend cooldown/queue =====
-    const COOLDOWN_MS = 10_000;
-    let nextSendAt = 0;            // timestamp when next send is allowed
-    let sendQueue = [];            // queued chat messages
-    let sendLoopTimer = null;      // setInterval handle
-    let progressTimer = null;      // setInterval handle for UI progress
-    let exportFillBtn = null;      // set in createMainButtons()
-    let exportEmptyBtn = null;     // set in createMainButtons()
-    let exportDartBtn = null;
-    let statusAltCmd = false;
-    // --- cleanup on unload ---
-    window.addEventListener("beforeunload", () => {
-        if (redeemButtonMonitorId) clearInterval(redeemButtonMonitorId);
-        if (activityBtnMonitorId) clearInterval(activityBtnMonitorId);
-        if (progressTimer) clearInterval(progressTimer);
-    });
-    // Clue dashes (left/top bands)
-    let rowDashes = [];   // array per row -> [canvasX,...]
-    let colDashes = [];   // array per col -> [posWithinTopClueArea,...]
-    // ---- Redemption Tracking ----
-    let redeemBtn;
-    let lastGuardRedeem = 0; // timestamp of last auto-redeem from guard
-
-    const REDEEM_KEY = "lastRedeemTimestamp";
-    // --- Redeem button monitor ---
-let redeemButtonMonitorId = null;
-let activityBtnMonitorId = null;
-function setLastRedeem(ts = Date.now()) {
-  try {
-    localStorage.setItem(REDEEM_KEY, String(ts));
-  } catch (e) {
-    console.warn("[Reward Redeemer] setLastRedeem failed:", e);
+  if (typeof state.uiConfig.sharpeningEnabled !== 'boolean') {
+    state.uiConfig.sharpeningEnabled = false;
   }
-}
 
-function getLastRedeem() {
-  const v = parseInt(localStorage.getItem(REDEEM_KEY) || "0", 10);
-  return Number.isFinite(v) ? v : 0;
-}
+  state.roiCtx = state.roiCanvas.getContext('2d');
+  state.anchorX = state.DEFAULT_CONF.anchorX;
+  state.anchorY = state.DEFAULT_CONF.anchorY;
+  state.zoomFactor = state.DEFAULT_CONF.zoomFactor;
+  state.fineTune = state.DEFAULT_CONF.fineTune;
+  state.showMinimizeButtons = state.uiConfig.showMinimizeButtons;
+  state.useBlueFill = state.uiConfig.useBlueFill;
+  state.statusEnabled = state.uiConfig.statusEnabled;
+  state.fineTuningEnabled = state.uiConfig.fineTuningEnabled;
+  state.sharpeningEnabled = state.uiConfig.sharpeningEnabled;
+  state.guard_Export = state.uiConfig.guardExport;
+  state.autosendEnabled = state.uiConfig.autosendEnabled ?? false;
 
-function minutesSinceRedeem() {
-  return (Date.now() - getLastRedeem()) / 60000;
-}
-let redeemBusy = false;
-async function redeemAndTrack() {
-  if (redeemBusy) {
-    console.log("[Reward Redeemer] Another redeem is in progress — skipping.");
+  function saveUIConfig() {
+    localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
+  }
+
+  const sizeLookup = {
+    '4_1': { cellSize: 90.7, anchorX: 1, anchorY: 10 },
+    '4_2': { cellSize: 85.3, anchorX: 1, anchorY: 10 },
+    '5_1': { cellSize: 73.3, anchorX: 1, anchorY: 10 },
+    '5_2': { cellSize: 69.3, anchorX: 1, anchorY: 10 },
+    '5_3': { cellSize: 65.3, anchorX: 1, anchorY: 10 },
+    '6_1': { cellSize: 61.3, anchorX: 1, anchorY: 10 },
+    '6_2': { cellSize: 57.3, anchorX: 1, anchorY: 10 },
+    '6_3': { cellSize: 54.6, anchorX: 1, anchorY: 10 },
+    '7_1': { cellSize: 51.9, anchorX: 1, anchorY: 10 },
+    '7_2': { cellSize: 49.5, anchorX: 1, anchorY: 10 },
+    '7_3': { cellSize: 46.7, anchorX: 1, anchorY: 10 },
+    '7_4': { cellSize: 44.1, anchorX: 1, anchorY: 10 },
+    '8_1': { cellSize: 45.3, anchorX: 1, anchorY: 10 },
+    '8_2': { cellSize: 42.7, anchorX: 1, anchorY: 10 },
+    '8_3': { cellSize: 41.3, anchorX: 1, anchorY: 10 },
+    '8_4': { cellSize: 38.7, anchorX: 1, anchorY: 10 },
+    '9_1': { cellSize: 40, anchorX: 1, anchorY: 10 },
+    '9_2': { cellSize: 38.7, anchorX: 1, anchorY: 10 },
+    '9_3': { cellSize: 37.3, anchorX: 1, anchorY: 10 },
+    '9_4': { cellSize: 34.7, anchorX: 1, anchorY: 10 },
+    '9_5': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+    '10_1': { cellSize: 36, anchorX: 1, anchorY: 10 },
+    '10_2': { cellSize: 34.7, anchorX: 1, anchorY: 10 },
+    '10_3': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+    '10_4': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+    '10_5': { cellSize: 29.3, anchorX: 1, anchorY: 10 },
+    '11_1': { cellSize: 33.3, anchorX: 1, anchorY: 10 },
+    '11_2': { cellSize: 32, anchorX: 1, anchorY: 10 },
+    '11_3': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+    '11_4': { cellSize: 29.4, anchorX: 1.75, anchorY: 10 },
+    '11_5': { cellSize: 28, anchorX: 1.75, anchorY: 10 },
+    '11_6': { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
+    '12_1': { cellSize: 30.7, anchorX: 1, anchorY: 10 },
+    '12_2': { cellSize: 29.3, anchorX: 1, anchorY: 10 },
+    '12_3': { cellSize: 28, anchorX: 1, anchorY: 10 },
+    '12_4': { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
+    '12_5': { cellSize: 25.3, anchorX: 1.75, anchorY: 10 },
+    '12_6': { cellSize: 24.1, anchorX: 1.75, anchorY: 10 },
+    '13_1': { cellSize: 28, anchorX: 1, anchorY: 10 },
+    '13_2': { cellSize: 26.7, anchorX: 1, anchorY: 10 },
+    '13_3': { cellSize: 25.4, anchorX: 1, anchorY: 10 },
+    '13_4': { cellSize: 25.4, anchorX: 1.5, anchorY: 10 },
+    '13_5': { cellSize: 24, anchorX: 1.5, anchorY: 10 },
+    '13_6': { cellSize: 22.7, anchorX: 1.5, anchorY: 10 },
+    '13_7': { cellSize: 21.4, anchorX: 1, anchorY: 10 },
+    '14_1': { cellSize: 26.7, anchorX: 1, anchorY: 10 },
+    '14_2': { cellSize: 25.3, anchorX: 1.5, anchorY: 10 },
+    '14_3': { cellSize: 24, anchorX: 1, anchorY: 10 },
+    '14_4': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+    '14_5': { cellSize: 21.3, anchorX: 1, anchorY: 10 },
+    '14_6': { cellSize: 21.4, anchorX: 1.5, anchorY: 10 },
+    '14_7': { cellSize: 20, anchorX: 1, anchorY: 10 },
+    '15_1': { cellSize: 24, anchorX: 1, anchorY: 10 },
+    '15_2': { cellSize: 24, anchorX: 1.5, anchorY: 10 },
+    '15_3': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+    '15_4': { cellSize: 21.3, anchorX: 4, anchorY: 10 },
+    '15_5': { cellSize: 21.3, anchorX: 1.5, anchorY: 10 },
+    '15_6': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+    '15_7': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '15_8': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '16_1': { cellSize: 22.6, anchorX: 1, anchorY: 10 },
+    '16_2': { cellSize: 22.7, anchorX: 1, anchorY: 10 },
+    '16_3': { cellSize: 21.3, anchorX: 1.25, anchorY: 10 },
+    '16_4': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+    '16_5': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+    '16_6': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '16_7': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+    '16_8': { cellSize: 17.4, anchorX: 1.5, anchorY: 10 },
+    '17_1': { cellSize: 21.3, anchorX: 1, anchorY: 10 },
+    '17_2': { cellSize: 21.4, anchorX: 1, anchorY: 10 },
+    '17_3': { cellSize: 20, anchorX: 1, anchorY: 10 },
+    '17_4': { cellSize: 18.7, anchorX: 1, anchorY: 10 },
+    '17_5': { cellSize: 18.7, anchorX: 1, anchorY: 10 },
+    '17_6': { cellSize: 17.3, anchorX: 1.75, anchorY: 10 },
+    '17_7': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+    '17_8': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+    '17_9': { cellSize: 14.7, anchorX: 1.5, anchorY: 10 },
+    '18_1': { cellSize: 20, anchorX: 1, anchorY: 10 },
+    '18_2': { cellSize: 20, anchorX: 1.5, anchorY: 10 },
+    '18_3': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '18_4': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '18_5': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+    '18_6': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+    '18_7': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+    '18_8': { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
+    '18_9': { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
+    '19_1': { cellSize: 18.6, anchorX: 1.5, anchorY: 10.5 },
+    '19_2': { cellSize: 18.6, anchorX: 4, anchorY: 10.5 },
+    '19_3': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+    '19_4': { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
+    '19_5': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+    '19_6': { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
+    '19_7': { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
+    '19_8': { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
+    '19_9': { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
+    '19_10': { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
+    '20_1': { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
+    '20_2': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+    '20_3': { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
+    '20_4': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+    '20_5': { cellSize: 16, anchorX: 1.5, anchorY: 10 },
+    '20_6': { cellSize: 14.65, anchorX: 1.5, anchorY: 10 },
+    '20_7': { cellSize: 14.6, anchorX: 1.5, anchorY: 10 },
+    '20_8': { cellSize: 13.3, anchorX: 1.75, anchorY: 10 },
+    '20_9': { cellSize: 13.3, anchorX: 1.5, anchorY: 10 },
+    '20_10': { cellSize: 12, anchorX: 1.5, anchorY: 10 }
+  };
+
+  const statusRegions = [
+    { sx: 200, sy: 980, sw: 250, sh: 70 },
+    { sx: 500, sy: 980, sw: 250, sh: 70 },
+    { sx: 800, sy: 980, sw: 250, sh: 70 }
+  ];
+
+  function getKey(sz, rc, cc) {
+    return `${sz}x${rc}x${cc}`;
+  }
+
+  function getLayoutSettings(size, colClueLength) {
+    const key = `${size}_${colClueLength}`;
+    const entry = sizeLookup[key];
+    if (!entry) {
+      console.warn(`No layout settings found for size=${size}, colClueLength=${colClueLength}`);
+      return null;
+    }
+    return {
+      cellSize: entry.cellSize,
+      anchorX: entry.anchorX,
+      anchorY: entry.anchorY
+    };
+  }
+
+  function saveLayout() {
+    const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+    state.configs[key] = {
+      ratio: state.ratio,
+      anchorX: state.anchorX,
+      anchorY: state.anchorY,
+      fineTune: state.fineTune,
+      size: state.size,
+      rowClueCount: state.rowClueCount,
+      colClueCount: state.colClueCount
+    };
+    localStorage.setItem('nonogramConfigMap', JSON.stringify(state.configs));
+  }
+
+  function loadLayout() {
+    const layout = getLayoutSettings(state.size, state.colClueCount);
+    if (layout) {
+      state.anchorX = layout.anchorX;
+      state.anchorY = layout.anchorY;
+    }
+    const key = getKey(state.size, state.rowClueCount, state.colClueCount);
+    const saved = state.configs[key];
+    if (saved) {
+      state.fineTune = saved.fineTune ?? state.fineTune;
+    }
+  }
+
+  function clearRenderHandle() {
+    if (!state.renderHandle) return;
+    if (typeof state.renderHandle === 'number') {
+      cancelAnimationFrame(state.renderHandle);
+    } else {
+      clearTimeout(state.renderHandle);
+    }
+    state.renderHandle = null;
+  }
+
+  // Integrates with Twitch chat, including message sending and autosend cooldown handling.
+
+  function send_message_with_event(message) {
+    if (!state.current_chat || !state.current_chat.props?.onSendMessage) {
+      state.current_chat = get_current_chat();
+    }
+
+    if (state.current_chat?.props?.onSendMessage) {
+      state.current_chat.props.onSendMessage(message);
+    } else {
+      console.error('Chat not available or missing onSendMessage. (Are you on a chat page and logged in?)');
+    }
+  }
+
+  function get_current_chat() {
+    try {
+      const chat_node = document.querySelector('section[data-test-selector="chat-room-component-layout"]');
+      if (!chat_node) return null;
+
+      const react_instance = get_react_instance(chat_node);
+      if (!react_instance) return null;
+
+      const chat_component = search_react_parents(
+        react_instance,
+        node => node.stateNode && node.stateNode.props && node.stateNode.props.onSendMessage
+      );
+
+      return chat_component ? chat_component.stateNode : null;
+    } catch (e) {
+      console.error('Error accessing chat:', e);
+      return null;
+    }
+  }
+
+  function get_react_instance(el) {
+    for (const k in el) {
+      if (k.startsWith('__reactInternalInstance$') || k.startsWith('__reactFiber$')) {
+        return el[k];
+      }
+    }
+    return null;
+  }
+
+  function search_react_parents(node, predicate, max_depth = 15, depth = 0) {
+    if (!node || depth > max_depth) return null;
+    try {
+      if (predicate(node)) return node;
+    } catch {}
+    return search_react_parents(node.return, predicate, max_depth, depth + 1);
+  }
+
+  function scheduleSend(msg) {
+    state.sendQueue.push(msg);
+    ensureSendLoop();
+    ensureProgressLoop();
+  }
+
+  function ensureSendLoop() {
+    if (state.sendLoopTimer) return;
+    state.sendLoopTimer = setInterval(() => {
+      const now = Date.now();
+      if (state.sendQueue.length > 0 && now >= state.nextSendAt) {
+        const next = state.sendQueue.shift();
+        try {
+          send_message_with_event(next);
+        } catch (e) {
+          console.error(e);
+        }
+        state.nextSendAt = now + state.COOLDOWN_MS;
+      }
+      if (state.sendQueue.length === 0 && now >= state.nextSendAt) {
+        clearInterval(state.sendLoopTimer);
+        state.sendLoopTimer = null;
+      }
+    }, 250);
+  }
+
+  function ensureProgressLoop() {
+    if (state.progressTimer) return;
+    state.progressTimer = setInterval(updateCooldownUI, 100);
+  }
+
+  function stopProgressLoop() {
+    if (state.progressTimer) {
+      clearInterval(state.progressTimer);
+      state.progressTimer = null;
+    }
+    setBtnProgress(state.exportFillBtn, null);
+    setBtnProgress(state.exportEmptyBtn, null);
+  }
+
+  function cooldownProgress01() {
+    const now = Date.now();
+    if (now < state.nextSendAt) return 1 - (state.nextSendAt - now) / state.COOLDOWN_MS;
+    if (state.sendQueue.length > 0) return 1;
+    return 1;
+  }
+
+  function updateCooldownUI() {
+    if (!state.autosendEnabled || (!state.exportFillBtn && !state.exportEmptyBtn)) return;
+    const p = cooldownProgress01();
+    const ready = Date.now() >= state.nextSendAt && state.sendQueue.length === 0;
+    [state.exportFillBtn, state.exportEmptyBtn, state.exportDartBtn].forEach(btn => {
+      if (!btn) return;
+      btn.disabled = !ready;
+      btn.style.opacity = ready ? '1' : '0.7';
+      btn.style.cursor = ready ? 'pointer' : 'not-allowed';
+    });
+    setBtnProgress(state.exportFillBtn, p);
+    setBtnProgress(state.exportEmptyBtn, p);
+
+    const remain = Math.max(0, state.nextSendAt - Date.now());
+    const seconds = Math.ceil(remain / 1000);
+    const title = remain > 0 ? `Cooldown: ${seconds}s` : (state.sendQueue.length ? `Queued: ${state.sendQueue.length}` : 'Ready');
+    if (state.exportFillBtn) state.exportFillBtn.title = title;
+    if (state.exportEmptyBtn) state.exportEmptyBtn.title = title;
+
+    if (!state.autosendEnabled || (state.sendQueue.length === 0 && Date.now() >= state.nextSendAt)) {
+      stopProgressLoop();
+    }
+  }
+
+  function setBtnProgress(btn, p) {
+    if (!btn) return;
+    if (p == null) {
+      btn.style.backgroundImage = '';
+      return;
+    }
+    const pct = Math.max(0, Math.min(1, p)) * 100;
+    btn.style.backgroundImage = `linear-gradient(to right, rgba(0,200,0,0.35) ${pct}%, transparent ${pct}%)`;
+  }
+
+  // Handles Twitch reward redemption, redeem timing, and guarded export behavior.
+
+  const TARGET_REWARD_NAME = 'Activity Coupon';
+  const PANEL_WAIT_TIMEOUT = 800;
+  const CONFIRM_POLL_INTERVAL = 300;
+  const CONFIRM_MAX_ATTEMPTS = 30;
+
+  function setLastRedeem(ts = Date.now()) {
+    try {
+      localStorage.setItem(state.REDEEM_KEY, String(ts));
+    } catch (e) {
+      console.warn('[Reward Redeemer] setLastRedeem failed:', e);
+    }
+  }
+
+  function getLastRedeem() {
+    const v = parseInt(localStorage.getItem(state.REDEEM_KEY) || '0', 10);
+    return Number.isFinite(v) ? v : 0;
+  }
+
+  function minutesSinceRedeem() {
+    return (Date.now() - getLastRedeem()) / 60000;
+  }
+
+  async function redeemAndTrack(onUpdateActivityButton) {
+    if (state.redeemBusy) {
+      console.log('[Reward Redeemer] Another redeem is in progress — skipping.');
+      return;
+    }
+    state.redeemBusy = true;
+    try {
+      console.log('[Reward Redeemer] Redeeming reward...');
+      const success = await attemptRedeemCycle();
+      if (success) {
+        setLastRedeem();
+        state.lastGuardRedeem = Date.now();
+        if (typeof onUpdateActivityButton === 'function') {
+          try {
+            onUpdateActivityButton();
+          } catch {}
+        }
+        scheduleAutoRedeem(onUpdateActivityButton);
+      } else {
+        console.log('[Reward Redeemer] Redeem attempt did not complete (timed out or no button).');
+      }
+    } finally {
+      state.redeemBusy = false;
+    }
+  }
+
+  function scheduleAutoRedeem(onUpdateActivityButton) {
     return;
   }
-  redeemBusy = true;
-  try {
-    console.log("[Reward Redeemer] Redeeming reward...");
-    const success = await attemptRedeemCycle();
-    if (success) {
-      setLastRedeem();            // <-- single place we persist the timestamp
-      lastGuardRedeem = Date.now(); // keep the in-memory cooldown in sync too
-      // update UI: call your button styling helper if available
-      if (typeof updateActivityBtnStyle === 'function') {
-        // if you have a reference to activityBtn, call with it
-        try { updateActivityBtnStyle(activityBtn); } catch {}
-      }
-      scheduleAutoRedeem(); // re-schedule
-    } else {
-      console.log("[Reward Redeemer] Redeem attempt did not complete (timed out or no button).");
-    }
-  } finally {
-    redeemBusy = false;
-  }
-}
-// ---- Auto-Redeem Scheduler ----
-let autoRedeemEnabled = false; // test if redemption is working
-let autoRedeemTimer = null;   // store active timer
-function scheduleAutoRedeem() {
-    if (!autoRedeemEnabled) return;
 
-    // Clear any existing timer before making a new one
-    if (autoRedeemTimer) {
-        clearTimeout(autoRedeemTimer);
-        autoRedeemTimer = null;
-    }
-
-    const delay = (40 + Math.random() * 15) * 60000; // 40–55 minutes
-    console.log(`[Reward Redeemer] Next auto redeem in ${(delay/60000).toFixed(1)} min`);
-
-    autoRedeemTimer = setTimeout(async () => {
-        await redeemAndTrack();
-        scheduleAutoRedeem(); // re-schedule after redemption
-    }, delay);
-}
-scheduleAutoRedeem();
-function createRedeemButton() {
-    redeemBtn = document.createElement('button');
-    redeemBtn.textContent = '🎟️ Redeem Reward';
-    redeemBtn.style.position = 'fixed';
-    redeemBtn.style.bottom = '20px';
-    redeemBtn.style.right = '20px';
-    redeemBtn.style.zIndex = '9999';
-    redeemBtn.style.padding = '10px 15px';
-    redeemBtn.style.background = '#9146FF';
-    redeemBtn.style.color = 'white';
-    redeemBtn.style.border = 'none';
-    redeemBtn.style.borderRadius = '6px';
-    redeemBtn.style.fontWeight = 'bold';
-    redeemBtn.style.cursor = 'pointer';
-    redeemBtn.style.boxShadow = '0 2px 6px rgba(0,0,0,0.3)';
-
-    redeemBtn.addEventListener('click', () => {
-        console.log('[Reward Redeemer] Manual redeem triggered.');
-        redeemAndTrack();
-    });
-
-    document.body.appendChild(redeemBtn);
-
-    // start monitoring after button is created
-    startRedeemButtonMonitor();
-}
-
-function startRedeemButtonMonitor() {
-  // Clear any previous monitor
-  if (redeemButtonMonitorId) {
-    clearInterval(redeemButtonMonitorId);
-    redeemButtonMonitorId = null;
-  }
-
-  redeemButtonMonitorId = setInterval(() => {
-    if (!redeemBtn) return;
-
-    const mins = minutesSinceRedeem();
-    if (mins > 45) {
-      redeemBtn.style.background = '#b22222'; // dark red
-    } else if (mins > 30) {
-      redeemBtn.style.background = '#ff4444'; // bright red
-    } else {
-      redeemBtn.style.background = '#9146FF'; // twitch purple
-    }
-  }, 60_000); // every 60s
-}
-
-// Call this when destroying UI (optional safeguard)
-function stopRedeemButtonMonitor() {
-  if (redeemButtonMonitorId) {
-    clearInterval(redeemButtonMonitorId);
-    redeemButtonMonitorId = null;
-  }
-}
-async function guardedExport(fn, ...args) {
-    if (!guard_Export) {
-        return fn(...args);
+  async function guardedExport(fn, ...args) {
+    if (!state.guard_Export) {
+      return fn(...args);
     }
 
     const minutes = minutesSinceRedeem();
     const now = Date.now();
 
     if (minutes > 55) {
-        if (now - lastGuardRedeem < 60_000) {
-            console.log("[Reward Redeemer] Guarded export skipped — redeem already attempted recently.");
-            return;
-        }
+      if (now - state.lastGuardRedeem < 60_000) {
+        console.log('[Reward Redeemer] Guarded export skipped — redeem already attempted recently.');
+        return;
+      }
 
-        console.log("[Reward Redeemer] Guarded export requires redeem...");
-        lastGuardRedeem = now;
-        await redeemAndTrack();
+      console.log('[Reward Redeemer] Guarded export requires redeem...');
+      state.lastGuardRedeem = now;
+      await redeemAndTrack();
     }
 
     return fn(...args);
-}
-    // ─── STATUS BAR REGIONS (for 1920×1080) ──────────────────────────────────────
-    const statusRegions = [
-        { sx: 200, sy: 980, sw: 250, sh: 70 },
-        { sx: 500, sy: 980, sw: 250, sh: 70 },
-        { sx: 800, sy: 980, sw: 250, sh: 70 }
-    ];
-    let statusCanvases = [];
+  }
 
-    const sizeLookup = {
-        "4_1": { cellSize: 90.7, anchorX: 1, anchorY: 10 },
-        "4_2": { cellSize: 85.3, anchorX: 1, anchorY: 10 },
-        "5_1": { cellSize: 73.3, anchorX: 1, anchorY: 10 },
-        "5_2": { cellSize: 69.3, anchorX: 1, anchorY: 10 },
-        "5_3": { cellSize: 65.3, anchorX: 1, anchorY: 10 },
-        "6_1": { cellSize: 61.3, anchorX: 1, anchorY: 10 },
-        "6_2": { cellSize: 57.3, anchorX: 1, anchorY: 10 },
-        "6_3": { cellSize: 54.6, anchorX: 1, anchorY: 10 },
-        "7_1": { cellSize: 51.9, anchorX: 1, anchorY: 10 },
-        "7_2": { cellSize: 49.5, anchorX: 1, anchorY: 10 },
-        "7_3": { cellSize: 46.7, anchorX: 1, anchorY: 10 },
-        "7_4": { cellSize: 44.1, anchorX: 1, anchorY: 10 },
-        "8_1": { cellSize: 45.3, anchorX: 1, anchorY: 10 },
-        "8_2": { cellSize: 42.7, anchorX: 1, anchorY: 10 },
-        "8_3": { cellSize: 41.3, anchorX: 1, anchorY: 10 },
-        "8_4": { cellSize: 38.7, anchorX: 1, anchorY: 10 },
-        "9_1": { cellSize: 40, anchorX: 1, anchorY: 10 },
-        "9_2": { cellSize: 38.7, anchorX: 1, anchorY: 10 },
-        "9_3": { cellSize: 37.3, anchorX: 1, anchorY: 10 },
-        "9_4": { cellSize: 34.7, anchorX: 1, anchorY: 10 },
-        "9_5": { cellSize: 33.3, anchorX: 1, anchorY: 10 },
-        "10_1": { cellSize: 36, anchorX: 1, anchorY: 10 },
-        "10_2": { cellSize: 34.7, anchorX: 1, anchorY: 10 },
-        "10_3": { cellSize: 33.3, anchorX: 1, anchorY: 10 },
-        "10_4": { cellSize: 30.7, anchorX: 1, anchorY: 10 },
-        "10_5": { cellSize: 29.3, anchorX: 1, anchorY: 10 },
-        "11_1": { cellSize: 33.3, anchorX: 1, anchorY: 10 },
-        "11_2": { cellSize: 32, anchorX: 1, anchorY: 10 },
-        "11_3": { cellSize: 30.7, anchorX: 1, anchorY: 10 },
-        "11_4": { cellSize: 29.4, anchorX: 1.75, anchorY: 10 },
-        "11_5": { cellSize: 28, anchorX: 1.75, anchorY: 10 },
-        "11_6": { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
-        "12_1": { cellSize: 30.7, anchorX: 1, anchorY: 10 },
-        "12_2": { cellSize: 29.3, anchorX: 1, anchorY: 10 },
-        "12_3": { cellSize: 28, anchorX: 1, anchorY: 10 },
-        "12_4": { cellSize: 26.7, anchorX: 1.75, anchorY: 10 },
-        "12_5": { cellSize: 25.3, anchorX: 1.75, anchorY: 10 },
-        "12_6": { cellSize: 24.1, anchorX: 1.75, anchorY: 10 },
-        "13_1": { cellSize: 28, anchorX: 1, anchorY: 10 },
-        "13_2": { cellSize: 26.7, anchorX: 1, anchorY: 10 },
-        "13_3": { cellSize: 25.4, anchorX: 1, anchorY: 10 },
-        "13_4": { cellSize: 25.4, anchorX: 1.5, anchorY: 10 },
-        "13_5": { cellSize: 24, anchorX: 1.5, anchorY: 10 },
-        "13_6": { cellSize: 22.7, anchorX: 1.5, anchorY: 10 },
-        "13_7": { cellSize: 21.4, anchorX: 1, anchorY: 10 },
-        "14_1": { cellSize: 26.7, anchorX: 1, anchorY: 10 },
-        "14_2": { cellSize: 25.3, anchorX: 1.5, anchorY: 10 },
-        "14_3": { cellSize: 24, anchorX: 1, anchorY: 10 },
-        "14_4": { cellSize: 22.7, anchorX: 1, anchorY: 10 },
-        "14_5": { cellSize: 21.3, anchorX: 1, anchorY: 10 },
-        "14_6": { cellSize: 21.4, anchorX: 1.5, anchorY: 10 },
-        "14_7": { cellSize: 20, anchorX: 1, anchorY: 10 },
-        "15_1": { cellSize: 24, anchorX: 1, anchorY: 10 },
-        "15_2": { cellSize: 24, anchorX: 1.5, anchorY: 10 },
-        "15_3": { cellSize: 22.7, anchorX: 1, anchorY: 10 },
-        "15_4": { cellSize: 21.3, anchorX: 4, anchorY: 10 },
-        "15_5": { cellSize: 21.3, anchorX: 1.5, anchorY: 10 },
-        "15_6": { cellSize: 20, anchorX: 1.5, anchorY: 10 },
-        "15_7": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "15_8": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "16_1": { cellSize: 22.6, anchorX: 1, anchorY: 10 },
-        "16_2": { cellSize: 22.7, anchorX: 1, anchorY: 10 },
-        "16_3": { cellSize: 21.3, anchorX: 1.25, anchorY: 10 },
-        "16_4": { cellSize: 20, anchorX: 1.5, anchorY: 10 },
-        "16_5": { cellSize: 20, anchorX: 1.5, anchorY: 10 },
-        "16_6": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "16_7": { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
-        "16_8": { cellSize: 17.4, anchorX: 1.5, anchorY: 10 },
-        "17_1": { cellSize: 21.3, anchorX: 1, anchorY: 10 },
-        "17_2": { cellSize: 21.4, anchorX: 1, anchorY: 10 },
-        "17_3": { cellSize: 20, anchorX: 1, anchorY: 10 },
-        "17_4": { cellSize: 18.7, anchorX: 1, anchorY: 10 },
-        "17_5": { cellSize: 18.7, anchorX: 1, anchorY: 10 },
-        "17_6": { cellSize: 17.3, anchorX: 1.75, anchorY: 10 },
-        "17_7": { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
-        "17_8": { cellSize: 16, anchorX: 1.5, anchorY: 10 },
-        "17_9": { cellSize: 14.7, anchorX: 1.5, anchorY: 10 },
-        "18_1": { cellSize: 20, anchorX: 1, anchorY: 10 },
-        "18_2": { cellSize: 20, anchorX: 1.5, anchorY: 10 },
-        "18_3": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "18_4": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "18_5": { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
-        "18_6": { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
-        "18_7": { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
-        "18_8": { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
-        "18_9": { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
-        "19_1": { cellSize: 18.6, anchorX: 1.5, anchorY: 10.5 },
-        "19_2": { cellSize: 18.6, anchorX: 4, anchorY: 10.5 },
-        "19_3": { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
-        "19_4": { cellSize: 17.3, anchorX: 1.5, anchorY: 10.5 },
-        "19_5": { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
-        "19_6": { cellSize: 16, anchorX: 1.5, anchorY: 10.5 },
-        "19_7": { cellSize: 14.6, anchorX: 1.5, anchorY: 10.5 },
-        "19_8": { cellSize: 14.7, anchorX: 1.5, anchorY: 10.5 },
-        "19_9": { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
-        "19_10": { cellSize: 13.3, anchorX: 1.5, anchorY: 10.5 },
-        "20_1": { cellSize: 18.7, anchorX: 1.5, anchorY: 10 },
-        "20_2": { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
-        "20_3": { cellSize: 17.3, anchorX: 1.5, anchorY: 10 },
-        "20_4": { cellSize: 16, anchorX: 1.5, anchorY: 10 },
-        "20_5": { cellSize: 16, anchorX: 1.5, anchorY: 10 },
-        "20_6": { cellSize: 14.65, anchorX: 1.5, anchorY: 10 },
-        "20_7": { cellSize: 14.6, anchorX: 1.5, anchorY: 10 },
-        "20_8": { cellSize: 13.3, anchorX: 1.75, anchorY: 10 },
-        "20_9": { cellSize: 13.3, anchorX: 1.5, anchorY: 10 },
-        "20_10": { cellSize: 12, anchorX: 1.5, anchorY: 10 },
-    };
-// === Twitch Reward Redeemer Core Functions ===
-
-const TARGET_REWARD_NAME = "Activity Coupon"; // change to your reward name
-const PANEL_WAIT_TIMEOUT = 800;
-const CONFIRM_POLL_INTERVAL = 300;
-const CONFIRM_MAX_ATTEMPTS = 30;
-
-function findPanelButton() {
+  function findPanelButton() {
     return document.querySelector('button[aria-label="Bits and Points Balances"]') ||
-           document.querySelector('[data-test-selector="community-points-summary"] button') ||
-           document.querySelector('button[data-test-selector="community-points-summary-button"]');
-}
+      document.querySelector('[data-test-selector="community-points-summary"] button') ||
+      document.querySelector('button[data-test-selector="community-points-summary-button"]');
+  }
 
-function openPanel() {
+  function openPanel() {
     const btn = findPanelButton();
     if (!btn) return false;
     btn.click();
     return true;
-}
+  }
 
-function waitForAnySelector(selectors, timeout = 3000) {
+  function waitForAnySelector(selectors, timeout = 3000) {
     const start = Date.now();
     return new Promise(resolve => {
-        const tick = () => {
-            for (const sel of selectors) {
-                const el = document.querySelector(sel);
-                if (el) return resolve(el);
-            }
-            if (Date.now() - start >= timeout) return resolve(null);
-            setTimeout(tick, 50);
-        };
-        tick();
-    });
-}
-
-function clickFirstLayerInPanel() {
-    // Find the image by its alt text
-    const img = document.querySelector('img[alt="'+TARGET_REWARD_NAME+'"]');
-
-    if (img) {
-        // Walk up the DOM to the nearest button ancestor
-        const button = img.closest('button');
-
-        if (button) {
-            button.click();
-            return true;
+      const tick = () => {
+        for (const sel of selectors) {
+          const el = document.querySelector(sel);
+          if (el) return resolve(el);
         }
+        if (Date.now() - start >= timeout) return resolve(null);
+        setTimeout(tick, 50);
+      };
+      tick();
+    });
+  }
+
+  function clickFirstLayerInPanel() {
+    const img = document.querySelector(`img[alt="${TARGET_REWARD_NAME}"]`);
+    if (img) {
+      const button = img.closest('button');
+      if (button) {
+        button.click();
+        return true;
+      }
     }
     return false;
-}
+  }
 
-function pollAndClickConfirm() {
-  return new Promise(resolve => {
-    let attempts = 0;
-    const poll = setInterval(() => {
-      attempts++;
-      const confirmButton = document.querySelector('button:has(p[data-test-selector="RewardText"])');
+  function pollAndClickConfirm() {
+    return new Promise(resolve => {
+      let attempts = 0;
+      const poll = setInterval(() => {
+        attempts++;
+        const confirmButton = document.querySelector('button:has(p[data-test-selector="RewardText"])');
 
-      if (confirmButton) {
-        const ariaAncestor = confirmButton.closest('[aria-hidden]');
-        if (!ariaAncestor || ariaAncestor.getAttribute('aria-hidden') !== 'true') {
-          try { confirmButton.click(); } catch (e) {}
-          clearInterval(poll);
-          resolve(true);   // <-- success
-          return;
+        if (confirmButton) {
+          const ariaAncestor = confirmButton.closest('[aria-hidden]');
+          if (!ariaAncestor || ariaAncestor.getAttribute('aria-hidden') !== 'true') {
+            try {
+              confirmButton.click();
+            } catch {}
+            clearInterval(poll);
+            resolve(true);
+            return;
+          }
         }
-      }
 
-      if (attempts >= CONFIRM_MAX_ATTEMPTS) {
-        clearInterval(poll);
-        resolve(false);  // <-- timed out / no confirm
-      }
-    }, CONFIRM_POLL_INTERVAL);
-  });
-}
-let busy = false;
-async function attemptRedeemCycle() {
-  if (busy) return false;
-  busy = true;
-  try {
-    const opened = openPanel();
-    if (!opened) { return false; }
+        if (attempts >= CONFIRM_MAX_ATTEMPTS) {
+          clearInterval(poll);
+          resolve(false);
+        }
+      }, CONFIRM_POLL_INTERVAL);
+    });
+  }
 
-    const rewardPanel = await waitForAnySelector(
+  async function attemptRedeemCycle() {
+    if (state.busy) return false;
+    state.busy = true;
+    try {
+      const opened = openPanel();
+      if (!opened) return false;
+
+      const rewardPanel = await waitForAnySelector(
         ['#channel-points-reward-center-body', '.rewards-list', '.reward-list-item'],
         PANEL_WAIT_TIMEOUT
-    );
-    if (!rewardPanel) { return false; }
+      );
+      if (!rewardPanel) return false;
 
-    const firstClicked = clickFirstLayerInPanel();
-    if (!firstClicked) { return false; }
+      const firstClicked = clickFirstLayerInPanel();
+      if (!firstClicked) return false;
 
-    await new Promise(resolve => setTimeout(resolve, 400));
-    const confirmed = await pollAndClickConfirm(); // true if clicked confirm
-
-    return !!confirmed;
-  } finally {
-    busy = false;
+      await new Promise(resolve => setTimeout(resolve, 400));
+      const confirmed = await pollAndClickConfirm();
+      return !!confirmed;
+    } finally {
+      state.busy = false;
+    }
   }
-}
-    function getKey(sz, rc, cc) {
-        return `${sz}x${rc}x${cc}`;
-    }
-    function getLayoutSettings(size, colClueLength) {
-        const key = `${size}_${colClueLength}`;
-        const entry = sizeLookup[key];
-        if (!entry) {
-            console.warn(`No layout settings found for size=${size}, colClueLength=${colClueLength}`);
-            return null;
-        }
-        return {
-            cellSize: entry.cellSize,
-            anchorX: entry.anchorX,
-            anchorY: entry.anchorY,
-        };
-    }
-    function saveLayout() {
-        const key = getKey(size, rowClueCount, colClueCount);
-        configs[key] = { ratio, anchorX, anchorY, fineTune, size, rowClueCount, colClueCount };
-        localStorage.setItem('nonogramConfigMap', JSON.stringify(configs));
-    }
-    function loadLayout() {
-        const layout = getLayoutSettings(size, colClueCount);
-        if (layout) {
-            anchorX = layout.anchorX;
-            anchorY = layout.anchorY;
-        }
-        const key = getKey(size, rowClueCount, colClueCount);
-        const saved = configs[key];
-        if (saved) {
-            fineTune = saved.fineTune ?? fineTune;
-        }
-    }
-    function initCells() {
-        cellStates = Array.from({ length: size }, () => Array(size).fill(0));
-        lastExported = new Set();
-        lastExportedWhite = new Set();
-        resetClueDashes();
-    }
-function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
 
-function exportDartCommand() {
-    let msg = "!darts";
+  // Owns nonogram state, geometry, drawing, exports, and canvas interaction logic.
+
+  let updateCanvasSizeRef$1;
+
+  function configureNonogramGrid({ updateCanvasSize }) {
+    updateCanvasSizeRef$1 = updateCanvasSize;
+  }
+
+  function initCells() {
+    state.cellStates = Array.from({ length: state.size }, () => Array(state.size).fill(0));
+    state.lastExported = new Set();
+    state.lastExportedWhite = new Set();
+    resetClueDashes();
+  }
+
+  function clamp(v, min, max) {
+    return Math.max(min, Math.min(max, v));
+  }
+
+  async function exportDartCommand() {
+    let msg = '!darts';
     for (let i = 0; i < msg.length; i++) {
-        if (i == lastDartExportIndex) {
-            msg = msg.substring(0, i) + msg[i].toUpperCase() + msg.substring(i + 1);
-            lastDartExportIndex++;
-            if (lastDartExportIndex >= msg.length) {
-                lastDartExportIndex = 1;
-            }
-            break;
+      if (i === state.lastDartExportIndex) {
+        msg = msg.substring(0, i) + msg[i].toUpperCase() + msg.substring(i + 1);
+        state.lastDartExportIndex++;
+        if (state.lastDartExportIndex >= msg.length) {
+          state.lastDartExportIndex = 1;
         }
+        break;
+      }
     }
-    if (autosendEnabled) {
-        scheduleSend(msg);
+    if (state.autosendEnabled) {
+      scheduleSend(msg);
+    } else {
+      navigator.clipboard.writeText(msg);
     }
-    else {
-        navigator.clipboard.writeText(msg);
-    }
-}
-
-// --- Column dashes (top clue area), pos is vertical offset within [0..clueH]
-function addColDash(col, pos, clueH) {
-  if (col < 0 || col >= size) return;
-  if (!Array.isArray(colDashes[col])) colDashes[col] = [];
-  colDashes[col].push(clamp(pos, 0, clueH));
-}
-function removeNearestColDash(col, pos, threshold = 10) {
-  const arr = colDashes[col]; if (!arr || !arr.length) return;
-  let best = -1, bestDist = Infinity;
-  for (let i = 0; i < arr.length; i++) {
-    const d = Math.abs(arr[i] - pos);
-    if (d < bestDist) { bestDist = d; best = i; }
-  }
-  if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
-}
-
-// --- Row dashes (left clue area), store absolute canvas X for precise draw
-function addRowDash(row, canvasX) {
-  if (row < 0 || row >= size) return;
-  if (!Array.isArray(rowDashes[row])) rowDashes[row] = [];
-  rowDashes[row].push(canvasX);
-}
-function removeNearestRowDash(row, canvasX, threshold = 10) {
-  const arr = rowDashes[row]; if (!arr || !arr.length) return;
-  let best = -1, bestDist = Infinity;
-  for (let i = 0; i < arr.length; i++) {
-    const d = Math.abs(arr[i] - canvasX);
-    if (d < bestDist) { bestDist = d; best = i; }
-  }
-  if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
-}
-function computeGridGeometry() {
-  // clue area sizing (you already use same logic in createGrid)
-  ctx.font = `bold 30px Arial`;
-  const clueW = ctx.measureText('0'.repeat(rowClueCount)).width;
-  const clueH = 30 * colClueCount + 5;
-
-  const layout = getLayoutSettings(size, colClueCount);
-  let cellSize;
-  if (layout) {
-    const defaultCellSize = layout.cellSize;
-    cellSize = (defaultCellSize * size + fineTune) / size;
-  } else {
-    const gridSize = Math.min(canvas.width - clueW, canvas.height - clueH);
-    cellSize = (gridSize + fineTune) / size;
   }
 
-  const ox = canvas.width - cellSize * size - anchorX; // left edge of grid
-  const oy = canvas.height - cellSize * size - anchorY; // top edge of grid
-
-  return { clueW, clueH, cellSize, ox, oy };
-}
-// Reset dash arrays whenever grid changes size
-function resetClueDashes() {
-  rowDashes = Array.from({ length: size }, () => []);
-  colDashes = Array.from({ length: size }, () => []);
-}
-    // ─── “Clean All” (wipes grid + copies clear command) ─────────────────────────
-    function cleanAll() {
-        initCells();
-        createGrid();
-        exportClearCommand();
-    }
-
-    function exportCells() {
-        const coords = [];
-        cellStates.forEach((row, r) => {
-            row.forEach((s, c) => {
-                if (s === 1) {
-                    const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-                    if (!lastExported.has(coord)) {
-                        coords.push(coord);
-                        lastExported.add(coord);
-                    }
-                }
-            });
-        });
-        if (coords.length) {
-            const msg = `!fill ${coords.join(' ')}`;
-            if (autosendEnabled) {
-                scheduleSend(msg);
-            }
-            else {
-                navigator.clipboard.writeText(msg);
-            }
-        }
-    }
-
-    // ─── “Export All Black” (ignores lastExported, grabs every filled cell) ─────
-    function exportAllCells(mode) {
-        // Always reset both trackers
-        lastExported.clear();
-        lastExportedWhite.clear();
-
-        // If no mode provided, behave as a pure reset (no export)
-        if (!mode) return;
-
-        const coords = [];
-
-        if (mode === 'black') {
-            cellStates.forEach((row, r) => {
-                row.forEach((s, c) => {
-                    if (s === 1) {
-                        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-                        coords.push(coord);
-                        lastExported.add(coord);
-                    }
-                });
-            });
-            if (coords.length) {
-                const msg = `!fill ${coords.join(' ')}`;
-                navigator.clipboard.writeText(msg);
-                if (autosendEnabled) scheduleSend(msg);
-            }
-        } else if (mode === 'white') {
-            cellStates.forEach((row, r) => {
-                row.forEach((s, c) => {
-                    if (s === 2) {
-                        const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-                        coords.push(coord);
-                        lastExportedWhite.add(coord);
-                    }
-                });
-            });
-            if (coords.length) {
-                const msg = `!empty ${coords.join(' ')}`;
-                navigator.clipboard.writeText(msg);
-                if (autosendEnabled) scheduleSend(msg);
-            }
-        }
-    }
-
-    function exportWhiteCells() {
-        const coords = [];
-        cellStates.forEach((row, r) => {
-            row.forEach((s, c) => {
-                if (s === 2) {
-                    const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
-                    if (!lastExportedWhite.has(coord)) {
-                        coords.push(coord);
-                        lastExportedWhite.add(coord);
-                    }
-                }
-            });
-        });
-        if (coords.length) {
-            const msg = `!empty ${coords.join(' ')}`;
-            if (autosendEnabled) {
-                scheduleSend(msg);
-            }
-            else {
-                navigator.clipboard.writeText(msg);
-            }
-        }
-
-    }
-    function exportClearCommand() {
-        const letters = 'abcdefghijklmnopqrstuvwxyz';
-        const ranges = [];
-        for (let c = 0; c < size; c++) {
-            const col = letters[c];
-            const start = `${col}1`;
-            const end = `${col}${size}`;
-            ranges.push(`${start}-${end}`);
-        }
-        const clearCmd = `!clear ${ranges.join(',')}`;
-        try {
-            navigator.clipboard.writeText(clearCmd);
-        } catch (e) {
-            console.warn("Clipboard write failed:", e);
-            alert(clearCmd);
-        }
-    }
-    function scheduleSend(msg) {
-  // queue and kick the loop
-  sendQueue.push(msg);
-  ensureSendLoop();
-  ensureProgressLoop();
-}
-// ─── Save Originals ─────────────────────────────
-const _exportAllCells = exportAllCells;
-const _exportWhiteCells = exportWhiteCells;
-const _exportCells = exportCells;
-const _cleanAll = cleanAll;
-
-// ─── Replace With Guarded Versions ──────────────
-exportAllCells = function(mode) {
-    return guardedExport(_exportAllCells, mode);
-};
-exportWhiteCells = function() {
-    return guardedExport(_exportWhiteCells);
-};
-exportCells = function() {
-    return guardedExport(_exportCells);
-};
-cleanAll = function() {
-    return guardedExport(_cleanAll);
-};
-// ========================
-// Twitch React Chat (no OAuth required)
-// ========================
-let current_chat;
-
-function send_message_with_event(message) {
-  if (!current_chat || !current_chat.props?.onSendMessage)
-    current_chat = get_current_chat();
-
-  if (current_chat?.props?.onSendMessage)
-    current_chat.props.onSendMessage(message);
-  else
-    console.error("Chat not available or missing onSendMessage. (Are you on a chat page and logged in?)");
-}
-
-function get_current_chat() {
-  try {
-    const chat_node = document.querySelector(`section[data-test-selector="chat-room-component-layout"]`);
-    if (!chat_node) return null;
-
-    const react_instance = get_react_instance(chat_node);
-    if (!react_instance) return null;
-
-    const chat_component = search_react_parents(react_instance, (node) =>
-      node.stateNode && node.stateNode.props && node.stateNode.props.onSendMessage
-    );
-
-    return chat_component ? chat_component.stateNode : null;
-  } catch (e) {
-    console.error("Error accessing chat:", e);
-    return null;
+  function addColDash(col, pos, clueH) {
+    if (col < 0 || col >= state.size) return;
+    if (!Array.isArray(state.colDashes[col])) state.colDashes[col] = [];
+    state.colDashes[col].push(clamp(pos, 0, clueH));
   }
-}
 
-function get_react_instance(el) {
-  for (const k in el)
-    if (k.startsWith("__reactInternalInstance$") || k.startsWith("__reactFiber$"))
-      return el[k];
-  return null;
-}
-function search_react_parents(node, predicate, max_depth = 15, depth = 0) {
-  if (!node || depth > max_depth) return null;
-  try { if (predicate(node)) return node; } catch {}
-  return search_react_parents(node.return, predicate, max_depth, depth + 1);
-}
-function ensureSendLoop() {
-  if (sendLoopTimer) return;
-  sendLoopTimer = setInterval(() => {
-    const now = Date.now();
-    if (sendQueue.length > 0 && now >= nextSendAt) {
-      const next = sendQueue.shift();
-      try { send_message_with_event(next); } catch (e) { console.error(e); }
-      nextSendAt = now + COOLDOWN_MS;
+  function removeNearestColDash(col, pos, threshold = 10) {
+    const arr = state.colDashes[col];
+    if (!arr || !arr.length) return;
+    let best = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < arr.length; i++) {
+      const d = Math.abs(arr[i] - pos);
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
     }
-    // stop if nothing to do and cooldown expired
-    if (sendQueue.length === 0 && now >= nextSendAt) {
-      clearInterval(sendLoopTimer);
-      sendLoopTimer = null;
-    }
-  }, 250);
-}
-
-function ensureProgressLoop() {
-  if (progressTimer) return;
-  progressTimer = setInterval(updateCooldownUI, 100);
-}
-
-function stopProgressLoop() {
-  if (progressTimer) {
-    clearInterval(progressTimer);
-    progressTimer = null;
+    if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
   }
-  // clear button visuals
-  setBtnProgress(exportFillBtn, null);
-  setBtnProgress(exportEmptyBtn, null);
-}
 
-function cooldownProgress01() {
-  const now = Date.now();
-  // When cooling down: 0 -> 1 over 10s. When ready: 1.
-  if (now < nextSendAt) return 1 - (nextSendAt - now) / COOLDOWN_MS;
-  // If messages are pending, keep bar full
-  if (sendQueue.length > 0) return 1;
-  return 1;
-}
+  function addRowDash(row, canvasX) {
+    if (row < 0 || row >= state.size) return;
+    if (!Array.isArray(state.rowDashes[row])) state.rowDashes[row] = [];
+    state.rowDashes[row].push(canvasX);
+  }
 
-function updateCooldownUI() {
-  // Only show when autosend is enabled and we have buttons
-  if (!autosendEnabled || (!exportFillBtn && !exportEmptyBtn)) return;
-  const p = cooldownProgress01();
-  // Disable while cooling down or while a queue exists
-    const ready = (Date.now() >= nextSendAt) && (sendQueue.length === 0);
-    [exportFillBtn, exportEmptyBtn, exportDartBtn].forEach(btn => {
-        if (!btn) return;
-        btn.disabled = !ready;
-        btn.style.opacity = ready ? '1' : '0.7';
-        btn.style.cursor  = ready ? 'pointer' : 'not-allowed';
+  function removeNearestRowDash(row, canvasX, threshold = 10) {
+    const arr = state.rowDashes[row];
+    if (!arr || !arr.length) return;
+    let best = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < arr.length; i++) {
+      const d = Math.abs(arr[i] - canvasX);
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    }
+    if (best !== -1 && bestDist <= threshold) arr.splice(best, 1);
+  }
+
+  function computeGridGeometry() {
+    state.ctx.font = 'bold 30px Arial';
+    const clueW = state.ctx.measureText('0'.repeat(state.rowClueCount)).width;
+    const clueH = 30 * state.colClueCount + 5;
+
+    const layout = getLayoutSettings(state.size, state.colClueCount);
+    let cellSize;
+    if (layout) {
+      const defaultCellSize = layout.cellSize;
+      cellSize = (defaultCellSize * state.size + state.fineTune) / state.size;
+    } else {
+      const gridSize = Math.min(state.canvas.width - clueW, state.canvas.height - clueH);
+      cellSize = (gridSize + state.fineTune) / state.size;
+    }
+
+    const ox = state.canvas.width - cellSize * state.size - state.anchorX;
+    const oy = state.canvas.height - cellSize * state.size - state.anchorY;
+
+    return { clueW, clueH, cellSize, ox, oy };
+  }
+
+  function resetClueDashes() {
+    state.rowDashes = Array.from({ length: state.size }, () => []);
+    state.colDashes = Array.from({ length: state.size }, () => []);
+  }
+
+  async function cleanAll() {
+    return guardedExport(() => {
+      initCells();
+      createGrid();
+      exportClearCommand();
     });
-  setBtnProgress(exportFillBtn, p);
-  setBtnProgress(exportEmptyBtn, p);
-
-  // Tooltip with time left
-  const now = Date.now();
-  const remain = Math.max(0, nextSendAt - now);
-  const seconds = Math.ceil(remain / 1000);
-  const title = remain > 0 ? `Cooldown: ${seconds}s` : (sendQueue.length ? `Queued: ${sendQueue.length}` : `Ready`);
-  if (exportFillBtn)  exportFillBtn.title  = title;
-  if (exportEmptyBtn) exportEmptyBtn.title = title;
-
-  // If autosend is off or nothing pending and cooldown done, we can stop loop
-  if (!autosendEnabled || (sendQueue.length === 0 && now >= nextSendAt)) {
-    stopProgressLoop();
-  }
-}
-
-// Paint a subtle progress fill behind the button label
-function setBtnProgress(btn, p) {
-  if (!btn) return;
-  if (p == null) {
-    btn.style.backgroundImage = '';
-    return;
-  }
-  const pct = Math.max(0, Math.min(1, p)) * 100;
-  // gradient fill from left → right; keeps your normal button color visible
-  btn.style.backgroundImage =
-    `linear-gradient(to right, rgba(0,200,0,0.35) ${pct}%, transparent ${pct}%)`;
-}
-    function disableShrinks() {
-        // Placeholder
-    }
-
-function createGrid() {
-  const { clueW, clueH, cellSize, ox, oy } = computeGridGeometry();
-
-  ctx.strokeStyle = 'cyan';
-  ctx.lineWidth = 1;
-
-  // ── Extended hover (row over left clues; column over top clues) ───────────
-  if ((hoveredRow >= 0 && hoveredRow < size) || (hoveredCol >= 0 && hoveredCol < size)) {
-    ctx.fillStyle = 'rgba(100, 150, 255, 0.25)';
-
-    if (hoveredRow >= 0) {
-      const y = oy + hoveredRow * cellSize;
-      // highlight entire row in grid
-      ctx.fillRect(ox, y, cellSize * size, cellSize);
-      // extend to left clue area
-      if (ox > 0) ctx.fillRect(0, y, ox, cellSize);
-    }
-
-    if (hoveredCol >= 0) {
-      const x = ox + hoveredCol * cellSize;
-      // highlight entire column in grid
-      ctx.fillRect(x, oy, cellSize, cellSize * size);
-      // extend through top clue band
-      ctx.fillRect(x, oy - clueH, cellSize, clueH);
-    }
   }
 
-  // ── Draw free-placed clue dashes ──────────────────────────────────────────
-  const dashH = 3;
-
-  // Top (column dashes). Each dash is centered at column center; vertical pos in [0..clueH]
-  {
-    const dashW = (1 * cellSize) / 3;
-    ctx.fillStyle = '#ffeb3b';
-    for (let c = 0; c < size; c++) {
-      const colX = ox + c * cellSize + cellSize / 2;
-      const baseY = oy - clueH; // top of top-clue area
-      const list = colDashes[c] || [];
-      for (const pos of list) {
-        const y = clamp(baseY + pos - dashH / 2, baseY, oy - dashH);
-        ctx.fillRect(colX - dashW / 2, y, dashW, dashH);
-      }
-    }
-  }
-
-  // Left (row dashes). Each dash is centered vertically in the row; X is absolute canvas X
-  {
-    const dashW = cellSize / 4;
-    ctx.fillStyle = '#ffeb3b';
-    for (let r = 0; r < size; r++) {
-      const rowTop = oy + r * cellSize;
-      const list = rowDashes[r] || [];
-      for (const canvasX of list) {
-        const xDraw = Math.max(0, Math.min(canvasX, ox)); // keep inside left area
-        const yDash = rowTop + (cellSize - dashH) / 2;
-        ctx.fillRect(xDraw - dashW / 2, yDash, dashW, dashH);
-      }
-    }
-  }
-
-  // ── Grid cells ────────────────────────────────────────────────────────────
-  for (let r = 0; r < size; r++) {
-    for (let c = 0; c < size; c++) {
-      const x = ox + c * cellSize;
-      const y = oy + r * cellSize;
-
-      if (cellStates[r][c] === 1) {
-        ctx.fillStyle = useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
-      } else if (cellStates[r][c] === 2) {
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
-      }
-
-      ctx.strokeRect(x, y, cellSize, cellSize);
-      if (cellStates[r][c] === 1 || cellStates[r][c] === 2) {
-        ctx.fillRect(x, y, cellSize, cellSize);
-        if (cellStates[r][c] === 2) ctx.fillStyle = 'black';
-      }
-    }
-  }
-}
-
-    function sharpen(ctx, w, h, mix) {
-        var x, sx, sy, r, g, b, a, dstOff, srcOff, wt, cx, cy, scy, scx,
-            weights = [0, -1, 0, -1, 5, -1, 0, -1, 0],
-            katet = Math.round(Math.sqrt(weights.length)),
-            half = (katet * 0.5) | 0,
-            dstData = ctx.createImageData(w, h),
-            dstBuff = dstData.data,
-            srcBuff = ctx.getImageData(0, 0, w, h).data,
-            y = h;
-
-        while (y--) {
-            x = w;
-            while (x--) {
-                sy = y;
-                sx = x;
-                dstOff = (y * w + x) * 4;
-                r = g = b = a = 0;
-
-                for (cy = 0; cy < katet; cy++) {
-                    for (cx = 0; cx < katet; cx++) {
-                        scy = sy + cy - half;
-                        scx = sx + cx - half;
-
-                        if (scy >= 0 && scy < h && scx >= 0 && scx < w) {
-                            srcOff = (scy * w + scx) * 4;
-                            wt = weights[cy * katet + cx];
-                            r += srcBuff[srcOff]     * wt;
-                            g += srcBuff[srcOff + 1] * wt;
-                            b += srcBuff[srcOff + 2] * wt;
-                            a += srcBuff[srcOff + 3] * wt;
-                        }
-                    }
-                }
-
-                dstBuff[dstOff]     = r * mix + srcBuff[dstOff]     * (1 - mix);
-                dstBuff[dstOff + 1] = g * mix + srcBuff[dstOff + 1] * (1 - mix);
-                dstBuff[dstOff + 2] = b * mix + srcBuff[dstOff + 2] * (1 - mix);
-                dstBuff[dstOff + 3] = srcBuff[dstOff + 3]; // keep alpha
-            }
+  function exportCellsInner() {
+    const coords = [];
+    state.cellStates.forEach((row, r) => {
+      row.forEach((s, c) => {
+        if (s === 1) {
+          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          if (!state.lastExported.has(coord)) {
+            coords.push(coord);
+            state.lastExported.add(coord);
+          }
         }
-
-        ctx.putImageData(dstData, 0, 0);
+      });
+    });
+    if (coords.length) {
+      const msg = `!fill ${coords.join(' ')}`;
+      if (state.autosendEnabled) {
+        scheduleSend(msg);
+      } else {
+        navigator.clipboard.writeText(msg);
+      }
     }
-    function updateROI() {
-        const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
-        if (!video) return;
+  }
 
-        roiCtx.clearRect(0, 0, roiCanvas.width, roiCanvas.height);
+  function exportAllCellsInner(mode) {
+    state.lastExported.clear();
+    state.lastExportedWhite.clear();
 
-        const actualWidth = video.videoWidth;
-        const actualHeight = video.videoHeight;
-        const roiWidth = actualWidth * roiWidthPercent;
-        const roiHeight = actualHeight * roiHeightPercent;
-        const roiX = actualWidth - roiWidth;
-        const roiY = actualHeight - roiHeight;
+    if (!mode) return;
 
-        roiCtx.drawImage(
-            video,
-            roiX, roiY, roiWidth, roiHeight,
-            0, 0, roiCanvas.width, roiCanvas.height
-        );
-
-        if (sharpeningEnabled) {
-            sharpen(roiCtx, roiCanvas.width, roiCanvas.height, 0.9);
-        }
-    }
-    function drawROI() {
-        const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
-        if (!video) return;
-
-        const actualWidth = video.videoWidth;
-        const actualHeight = video.videoHeight;
-        const roiWidth = actualWidth * roiWidthPercent;
-        const roiHeight = actualHeight * roiHeightPercent;
-        const roiX = actualWidth - roiWidth;
-        const roiY = actualHeight - roiHeight;
-
-        ctx.drawImage(
-            video,
-            roiX, roiY, roiWidth, roiHeight,
-            0, 0, canvas.width, canvas.height
-        );
-
-        if (sharpeningEnabled) {
-            sharpen(ctx, canvas.width, canvas.height, 0.9);
-        }
-    }
-
-    function updateCanvasSize() {
-        const fixedWidth = Math.round(428 * (0.36 / 0.335)); // ≈ 459
-        const fixedHeight = 420;
-
-        canvas.width = fixedWidth;
-        canvas.height = fixedHeight;
-        roiCanvas.width = canvas.width;
-        roiCanvas.height = canvas.height;
-        canvas.style.width = `${fixedWidth * zoomFactor}px`;
-        canvas.style.height = `${fixedHeight * zoomFactor}px`;
-        frame.style.width = `${fixedWidth * zoomFactor}px`;
-        frame.style.height = `${fixedHeight * zoomFactor + 60}px`;
-
-        createGrid();
-        updateROI();
-    }
-
-    // ─── DRAW STATUS CANVASES (scaled to actual video resolution) ─────────────────
-    function drawStatus() {
-        const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
-        if (!video) return;
-
-        const actualWidth = video.videoWidth;
-        const actualHeight = video.videoHeight;
-        const scaleX = actualWidth / 1920;
-        const scaleY = actualHeight / 1080;
-
-        statusCanvases.forEach(({ canvas: sc, ctx: sctx, region }) => {
-            const sx = region.sx * scaleX;
-            const sy = region.sy * scaleY;
-            const sw = region.sw * scaleX;
-            const sh = region.sh * scaleY;
-
-            sctx.clearRect(0, 0, sc.width, sc.height);
-            sctx.drawImage(
-                video,
-                sx, sy, sw, sh,
-                0, 0, sc.width, sc.height
-            );
+    const coords = [];
+    if (mode === 'black') {
+      state.cellStates.forEach((row, r) => {
+        row.forEach((s, c) => {
+          if (s === 1) {
+            const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+            coords.push(coord);
+            state.lastExported.add(coord);
+          }
         });
+      });
+      if (coords.length) {
+        const msg = `!fill ${coords.join(' ')}`;
+        navigator.clipboard.writeText(msg);
+        if (state.autosendEnabled) scheduleSend(msg);
+      }
+    } else if (mode === 'white') {
+      state.cellStates.forEach((row, r) => {
+        row.forEach((s, c) => {
+          if (s === 2) {
+            const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+            coords.push(coord);
+            state.lastExportedWhite.add(coord);
+          }
+        });
+      });
+      if (coords.length) {
+        const msg = `!empty ${coords.join(' ')}`;
+        navigator.clipboard.writeText(msg);
+        if (state.autosendEnabled) scheduleSend(msg);
+      }
     }
-    // ────────────────────────────────────────────────────────────────────────────
+  }
 
-    function render() {
-        // Skip if minimized or canvas is hidden
-        if (isMinimized || canvas.style.display === 'none') {
-            return;
+  function exportWhiteCellsInner() {
+    const coords = [];
+    state.cellStates.forEach((row, r) => {
+      row.forEach((s, c) => {
+        if (s === 2) {
+          const coord = `${String.fromCharCode(97 + c)}${r + 1}`;
+          if (!state.lastExportedWhite.has(coord)) {
+            coords.push(coord);
+            state.lastExportedWhite.add(coord);
+          }
+        }
+      });
+    });
+    if (coords.length) {
+      const msg = `!empty ${coords.join(' ')}`;
+      if (state.autosendEnabled) {
+        scheduleSend(msg);
+      } else {
+        navigator.clipboard.writeText(msg);
+      }
+    }
+  }
+
+  function exportCells() {
+    return guardedExport(exportCellsInner);
+  }
+
+  function exportAllCells(mode) {
+    return guardedExport(exportAllCellsInner, mode);
+  }
+
+  function exportWhiteCells() {
+    return guardedExport(exportWhiteCellsInner);
+  }
+
+  function exportClearCommand() {
+    const letters = 'abcdefghijklmnopqrstuvwxyz';
+    const ranges = [];
+    for (let c = 0; c < state.size; c++) {
+      const col = letters[c];
+      ranges.push(`${col}1-${col}${state.size}`);
+    }
+    const clearCmd = `!clear ${ranges.join(',')}`;
+    try {
+      navigator.clipboard.writeText(clearCmd);
+    } catch (e) {
+      console.warn('Clipboard write failed:', e);
+      alert(clearCmd);
+    }
+  }
+
+  function createGrid() {
+    const { clueH, cellSize, ox, oy } = computeGridGeometry();
+
+    state.ctx.strokeStyle = 'cyan';
+    state.ctx.lineWidth = 1;
+
+    if ((state.hoveredRow >= 0 && state.hoveredRow < state.size) || (state.hoveredCol >= 0 && state.hoveredCol < state.size)) {
+      state.ctx.fillStyle = 'rgba(100, 150, 255, 0.25)';
+
+      if (state.hoveredRow >= 0) {
+        const y = oy + state.hoveredRow * cellSize;
+        state.ctx.fillRect(ox, y, cellSize * state.size, cellSize);
+        if (ox > 0) state.ctx.fillRect(0, y, ox, cellSize);
+      }
+
+      if (state.hoveredCol >= 0) {
+        const x = ox + state.hoveredCol * cellSize;
+        state.ctx.fillRect(x, oy, cellSize, cellSize * state.size);
+        state.ctx.fillRect(x, oy - clueH, cellSize, clueH);
+      }
+    }
+
+    const dashH = 3;
+
+    {
+      const dashW = cellSize / 3;
+      state.ctx.fillStyle = '#ffeb3b';
+      for (let c = 0; c < state.size; c++) {
+        const colX = ox + c * cellSize + cellSize / 2;
+        const baseY = oy - clueH;
+        const list = state.colDashes[c] || [];
+        for (const pos of list) {
+          const y = clamp(baseY + pos - dashH / 2, baseY, oy - dashH);
+          state.ctx.fillRect(colX - dashW / 2, y, dashW, dashH);
+        }
+      }
+    }
+
+    {
+      const dashW = cellSize / 4;
+      state.ctx.fillStyle = '#ffeb3b';
+      for (let r = 0; r < state.size; r++) {
+        const rowTop = oy + r * cellSize;
+        const list = state.rowDashes[r] || [];
+        for (const canvasX of list) {
+          const xDraw = Math.max(0, Math.min(canvasX, ox));
+          const yDash = rowTop + (cellSize - dashH) / 2;
+          state.ctx.fillRect(xDraw - dashW / 2, yDash, dashW, dashH);
+        }
+      }
+    }
+
+    for (let r = 0; r < state.size; r++) {
+      for (let c = 0; c < state.size; c++) {
+        const x = ox + c * cellSize;
+        const y = oy + r * cellSize;
+
+        if (state.cellStates[r][c] === 1) {
+          state.ctx.fillStyle = state.useBlueFill ? 'rgba(50, 50, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)';
+        } else if (state.cellStates[r][c] === 2) {
+          state.ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
         }
 
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.drawImage(roiCanvas, 0, 0);
+        state.ctx.strokeRect(x, y, cellSize, cellSize);
+        if (state.cellStates[r][c] === 1 || state.cellStates[r][c] === 2) {
+          state.ctx.fillRect(x, y, cellSize, cellSize);
+          if (state.cellStates[r][c] === 2) state.ctx.fillStyle = 'black';
+        }
+      }
+    }
+  }
+
+  function onCanvasMouseDown(e) {
+    e.preventDefault();
+
+    const rect = state.canvas.getBoundingClientRect();
+    const scaleX = state.canvas.width / rect.width;
+    const scaleY = state.canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+
+    const { clueH, cellSize, ox, oy } = computeGridGeometry();
+    const yOverGrid = y >= oy && y < oy + state.size * cellSize;
+
+    const inTopClues = x >= ox && x < ox + state.size * cellSize && y >= oy - clueH && y < oy;
+    if (inTopClues) {
+      const col = Math.floor((x - ox) / cellSize);
+      if (col >= 0 && col < state.size) {
+        const pos = y - (oy - clueH);
+        if (e.button === 0) addColDash(col, pos, clueH);
+        else if (e.button === 2) removeNearestColDash(col, pos, 10);
         createGrid();
-        if (statusEnabled) drawStatus();
-
-        if (!document.hidden) {
-            renderHandle = requestAnimationFrame(render);
-        } else {
-            renderHandle = setTimeout(render, 1000 / 30);
-        }
+        return;
+      }
     }
 
-
-    function minimizeCanvas() {
-        isMinimized = true;
-        if (renderHandle) {
-            if (typeof renderHandle === 'number') {
-                cancelAnimationFrame(renderHandle);
-            } else {
-                clearTimeout(renderHandle);
-            }
-        }
-
-        canvas.style.display = 'none';
-        frame.style.height = '0px';
-        frame.style.width = '0px';
-
-        const ctrl = document.getElementById('control-container');
-        if (ctrl) ctrl.style.display = 'none';
-
-        const btns = document.getElementById('button-container');
-        if (btns) btns.style.display = 'none';
-
-        const cfg = document.getElementById('config-panel');
-        if (cfg) cfg.style.display = 'none';
-
-        const extraCfg = document.getElementById('extra-config-panel');
-        if (extraCfg) extraCfg.style.display = 'none';
-
-        const statusCont = document.getElementById('status-container');
-        if (statusCont) statusCont.style.display = 'none';
-
-        const restoreBtn = document.getElementById('restore-button');
-        if (restoreBtn) restoreBtn.style.display = 'block';
-
-        if (minimizeBtn && minimizeBtn.parentElement) {
-            minimizeBtn.remove();
-            minimizeBtn = null;
-        }
+    const inLeftClues = x < ox && yOverGrid;
+    if (inLeftClues) {
+      const row = Math.floor((y - oy) / cellSize);
+      if (row >= 0 && row < state.size) {
+        if (e.button === 0) addRowDash(row, x);
+        else if (e.button === 2) removeNearestRowDash(row, x, 10);
+        createGrid();
+        return;
+      }
     }
 
-    function restoreCanvas() {
-        isMinimized = false;
-        canvas.style.display = 'block';
-        updateCanvasSize();
-        render();
+    const c = Math.floor((x - ox) / cellSize);
+    const r = Math.floor((y - oy) / cellSize);
 
-        frame.style.height = `${canvas.height * zoomFactor + 40}px`;
-        frame.style.width = `${canvas.width * zoomFactor}px`;
+    if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
+      state.isMarking = true;
+      state.markValue = e.button === 0 ? 1 : 2;
+      state.eraseMode = state.cellStates[r][c] === state.markValue;
 
-        const ctrl = document.getElementById('control-container');
-        if (ctrl) ctrl.style.display = 'block';
+      const prevValue = state.cellStates[r][c];
+      const newValue = state.eraseMode ? 0 : state.markValue;
+      state.cellStates[r][c] = newValue;
+      state.currentAction = [{ row: r, col: c, previous: prevValue, newValue }];
+      createGrid();
+    } else {
+      state.isDragging = true;
+      state.dragOffsetX = e.clientX - state.frame.offsetLeft;
+      state.dragOffsetY = e.clientY - state.frame.offsetTop;
+    }
+  }
 
-        const btns = document.getElementById('button-container');
-        if (btns) btns.style.display = 'flex';
+  function onCanvasMouseMove(e) {
+    const rect = state.canvas.getBoundingClientRect();
+    const scaleX = state.canvas.width / rect.width;
+    const scaleY = state.canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
 
+    const { clueH, cellSize, ox, oy } = computeGridGeometry();
+    const c = Math.floor((x - ox) / cellSize);
+    const r = Math.floor((y - oy) / cellSize);
+
+    let newRow = -1;
+    let newCol = -1;
+
+    const yOverGrid = y >= oy && y < oy + state.size * cellSize;
+    if (yOverGrid) {
+      const ry = Math.floor((y - oy) / cellSize);
+      if (ry >= 0 && ry < state.size) newRow = ry;
+    }
+
+    const inTopClues = x >= ox && x < ox + state.size * cellSize && y >= oy - clueH && y < oy;
+    if (inTopClues) {
+      const col = Math.floor((x - ox) / cellSize);
+      if (col >= 0 && col < state.size) newCol = col;
+    }
+
+    if (r >= 0 && r < state.size && c >= 0 && c < state.size) {
+      newRow = r;
+      newCol = c;
+    }
+
+    state.hoveredRow = newRow;
+    state.hoveredCol = newCol;
+
+    if (state.isMarking && newRow >= 0 && newCol >= 0) {
+      const targetValue = state.eraseMode ? 0 : state.markValue;
+      if (state.cellStates[newRow][newCol] !== targetValue) {
+        if (!state.currentAction) state.currentAction = [];
+        state.currentAction.push({
+          row: newRow,
+          col: newCol,
+          previous: state.cellStates[newRow][newCol],
+          newValue: targetValue
+        });
+        state.cellStates[newRow][newCol] = targetValue;
+      }
+    }
+
+    createGrid();
+  }
+
+  function undoLastAction() {
+    if (!state.moveHistory.length) return;
+    const lastAction = state.moveHistory.pop();
+    lastAction.forEach(({ row, col, previous, newValue }) => {
+      const coord = `${String.fromCharCode(97 + col)}${row + 1}`;
+      if (newValue === 1) state.lastExported.delete(coord);
+      if (newValue === 2) state.lastExportedWhite.delete(coord);
+      state.cellStates[row][col] = previous;
+    });
+    createGrid();
+  }
+
+  function decrementSize() {
+    state.size = Math.max(1, state.size - 1);
+    loadLayout();
+    initCells();
+    updateCanvasSizeRef$1();
+  }
+
+  function incrementSize() {
+    state.size++;
+    loadLayout();
+    initCells();
+    updateCanvasSizeRef$1();
+  }
+
+  function decrementCols() {
+    state.colClueCount = Math.max(1, state.colClueCount - 1);
+    loadLayout();
+    initCells();
+    updateCanvasSizeRef$1();
+  }
+
+  function incrementCols() {
+    state.colClueCount++;
+    loadLayout();
+    initCells();
+    updateCanvasSizeRef$1();
+  }
+
+  function decrementFineTune() {
+    state.fineTune--;
+    saveLayout();
+    updateCanvasSizeRef$1();
+  }
+
+  function incrementFineTune() {
+    state.fineTune++;
+    saveLayout();
+    updateCanvasSizeRef$1();
+  }
+
+  function resetSizeDefaults() {
+    saveLayout();
+    state.size = 4;
+    state.rowClueCount = 1;
+    state.colClueCount = 1;
+    initCells();
+    updateCanvasSizeRef$1();
+  }
+
+  // Builds the side controls, extra settings panel, and clickable status preview canvases.
+
+  let updateCanvasSizeRef;
+  let createGridRef;
+  let minimizeCanvasRef;
+
+  function configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas }) {
+    updateCanvasSizeRef = updateCanvasSize;
+    createGridRef = createGrid;
+    minimizeCanvasRef = minimizeCanvas;
+  }
+
+  function createControlPanel() {
+    const controlContainer = document.createElement('div');
+    controlContainer.id = 'control-container';
+    Object.assign(controlContainer.style, {
+      position: 'absolute',
+      right: '-160px',
+      top: '0',
+      zIndex: '10001',
+      padding: '8px',
+      background: '#fff',
+      border: '1px solid #000',
+      borderRadius: '4px',
+      boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
+      lineHeight: '1.4em',
+      color: 'black',
+      width: '160px'
+    });
+
+    state.frame.appendChild(controlContainer);
+
+    state.labelMap = {};
+    state.controlSections = [
+      { key: 'size', label: 'Grid size', get: () => state.size, dec: decrementSize, inc: incrementSize },
+      { key: 'cols', label: 'Col clues', get: () => state.colClueCount, dec: decrementCols, inc: incrementCols },
+      { key: 'fine', label: 'Fine tune', get: () => state.fineTune, dec: decrementFineTune, inc: incrementFineTune }
+    ];
+
+    state.controlSections.forEach((s, i) => {
+      const sec = document.createElement('div');
+      sec.id = `section-${s.key}`;
+      if (s.key === 'fine' && !state.fineTuningEnabled) {
+        sec.style.display = 'none';
+      }
+
+      const lbl = document.createElement('div');
+      lbl.textContent = `${s.label}: ${s.get()}`;
+      state.labelMap[s.key] = lbl;
+      lbl.style.fontWeight = 'bold';
+      lbl.style.marginBottom = '4px';
+      sec.appendChild(lbl);
+
+      const row = document.createElement('div');
+      Object.assign(row.style, {
+        display: 'flex',
+        gap: '4px',
+        marginBottom: '8px',
+        alignItems: 'center'
+      });
+
+      [['−', s.dec], ['+', s.inc]].forEach(([symbol, fn]) => {
+        const btn = document.createElement('button');
+        btn.textContent = symbol;
+        Object.assign(btn.style, {
+          width: '28px',
+          height: '28px',
+          border: '1px solid #007bff',
+          borderRadius: '4px',
+          fontSize: '16px',
+          cursor: 'pointer',
+          backgroundColor: '#007bff',
+          color: 'white',
+          textAlign: 'center'
+        });
+        btn.addEventListener('click', () => {
+          fn();
+          lbl.textContent = `${s.label}: ${s.get()}`;
+        });
+        row.appendChild(btn);
+      });
+
+      if (s.key === 'size') {
+        const spacer = document.createElement('div');
+        spacer.style.flex = '1';
+        row.appendChild(spacer);
+
+        const resetBtn = document.createElement('button');
+        resetBtn.textContent = '4';
+        Object.assign(resetBtn.style, {
+          width: '28px',
+          height: '28px',
+          border: '1px solid #28a745',
+          borderRadius: '4px',
+          fontSize: '16px',
+          cursor: 'pointer',
+          backgroundColor: '#28a745',
+          color: 'white',
+          textAlign: 'center'
+        });
+        resetBtn.addEventListener('click', () => {
+          resetSizeDefaults();
+          lbl.textContent = `${s.label}: ${s.get()}`;
+        });
+        row.appendChild(resetBtn);
+      }
+
+      if (s.key === 'cols') {
+        const spacer = document.createElement('div');
+        spacer.style.flex = '1';
+        row.appendChild(spacer);
+
+        state.exportDartBtn = document.createElement('button');
+        state.exportDartBtn.textContent = '🎯';
+        Object.assign(state.exportDartBtn.style, {
+          width: '28px',
+          height: '28px',
+          border: '1px solid #D6B1AA',
+          borderRadius: '4px',
+          fontSize: '16px',
+          cursor: 'pointer',
+          backgroundColor: '#FFFFFF',
+          color: 'white',
+          textAlign: 'center'
+        });
+        state.exportDartBtn.addEventListener('click', exportDartCommand);
+        row.appendChild(state.exportDartBtn);
+      }
+
+      sec.appendChild(row);
+      controlContainer.appendChild(sec);
+      if (i < state.controlSections.length - 1) controlContainer.appendChild(document.createElement('hr'));
+    });
+
+    const magSec = document.createElement('div');
+    magSec.id = 'section-zoom';
+
+    const magLbl = document.createElement('div');
+    magLbl.textContent = 'Magnification';
+    magLbl.style.fontWeight = 'bold';
+    magLbl.style.marginBottom = '4px';
+    magSec.appendChild(magLbl);
+
+    const magRow = document.createElement('div');
+    Object.assign(magRow.style, {
+      display: 'flex',
+      gap: '4px',
+      marginBottom: '8px',
+      alignItems: 'center'
+    });
+
+    const makeZoomBtn = (label, onClick) => {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      Object.assign(btn.style, {
+        width: '28px',
+        height: '28px',
+        border: '1px solid #007bff',
+        borderRadius: '4px',
+        fontSize: '16px',
+        cursor: 'pointer',
+        backgroundColor: '#007bff',
+        color: 'white',
+        textAlign: 'center'
+      });
+      btn.addEventListener('click', onClick);
+      return btn;
+    };
+
+    magRow.appendChild(makeZoomBtn('−', () => {
+      state.zoomFactor = Math.max(0.1, state.zoomFactor * 0.9);
+      updateCanvasSizeRef();
+    }));
+    magRow.appendChild(makeZoomBtn('+', () => {
+      state.zoomFactor = state.zoomFactor * 1.1;
+      updateCanvasSizeRef();
+    }));
+
+    magSec.appendChild(magRow);
+    controlContainer.appendChild(magSec);
+  }
+
+  function createExtraConfigPanel() {
+    if (document.getElementById('extra-config-panel')) return;
+
+    const panel = document.createElement('div');
+    panel.id = 'extra-config-panel';
+    panel.style.cssText = `
+    position: absolute;
+    top: 40px;
+    left: 0;
+    background: #f9f9f9;
+    padding: 12px;
+    border: 1px solid #333;
+    border-radius: 6px;
+    z-index: 10002;
+    display: none;
+    color: black;
+    font-size: 14px;
+    width: 200px;
+  `;
+
+    const minDiv = document.createElement('div');
+    const minChk = document.createElement('input');
+    minChk.type = 'checkbox';
+    minChk.id = 'chk-minimize';
+    minChk.checked = state.showMinimizeButtons;
+    minChk.style.marginRight = '6px';
+    minChk.addEventListener('change', () => {
+      state.showMinimizeButtons = minChk.checked;
+      state.uiConfig.showMinimizeButtons = state.showMinimizeButtons;
+      saveUIConfig();
+      if (state.showMinimizeButtons) {
+        if (!state.minimizeBtn && !state.isMinimized) {
+          state.minimizeBtn = document.createElement('button');
+          state.minimizeBtn.textContent = 'X';
+          Object.assign(state.minimizeBtn.style, {
+            position: 'absolute',
+            top: '4px',
+            left: '4px',
+            width: '24px',
+            height: '24px',
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: '22px',
+            textAlign: 'center',
+            zIndex: 10002,
+            background: '#f0f0f0',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            padding: '0',
+            color: 'black'
+          });
+          state.minimizeBtn.onclick = minimizeCanvasRef;
+          state.frame.appendChild(state.minimizeBtn);
+        }
+      } else {
+        if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+          state.minimizeBtn.remove();
+          state.minimizeBtn = null;
+        }
         const restoreBtn = document.getElementById('restore-button');
         if (restoreBtn) restoreBtn.style.display = 'none';
-
-        const statusCont = document.getElementById('status-container');
-        if (statusCont) statusCont.style.display = statusEnabled ? 'block' : 'none';
-
-        if (showMinimizeButtons && !minimizeBtn) {
-            minimizeBtn = document.createElement('button');
-            minimizeBtn.textContent = 'X';
-            Object.assign(minimizeBtn.style, {
-                position: 'absolute',
-                top: '4px',
-                left: '4px',
-                width: '24px',
-                height: '24px',
-                fontWeight: 'bold',
-                fontSize: '16px',
-                lineHeight: '22px',
-                textAlign: 'center',
-                zIndex: 10002,
-                background: '#f0f0f0',
-                border: '1px solid #444',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                padding: '0',
-                color: 'black'
-            });
-            minimizeBtn.onclick = minimizeCanvas;
-            frame.appendChild(minimizeBtn);
-        }
-    }
-function onCanvasMouseDown(e) {
-  e.preventDefault();
-
-  const rect = canvas.getBoundingClientRect();
-  const scaleX = canvas.width / rect.width;
-  const scaleY = canvas.height / rect.height;
-  const x = (e.clientX - rect.left) * scaleX;
-  const y = (e.clientY - rect.top) * scaleY;
-
-  const { clueW, clueH, cellSize, ox, oy } = computeGridGeometry();
-  const yOverGrid = (y >= oy && y < oy + size * cellSize);
-
-  // --- Top clue band (column dashes) ---
-  const inTopClues = (x >= ox && x < ox + size * cellSize && y >= oy - clueH && y < oy);
-  if (inTopClues) {
-    const col = Math.floor((x - ox) / cellSize);
-    if (col >= 0 && col < size) {
-      const pos = y - (oy - clueH); // vertical offset inside [0..clueH]
-      if (e.button === 0) addColDash(col, pos, clueH);     // Right click: add
-      else if (e.button === 2) removeNearestColDash(col, pos, 10); // Left: remove
-      createGrid();
-      return;
-    }
-  }
-
-  // --- Left clue band (row dashes) ---
-  const inLeftClues = (x < ox && yOverGrid);
-  if (inLeftClues) {
-    const row = Math.floor((y - oy) / cellSize);
-    if (row >= 0 && row < size) {
-      if (e.button === 0) addRowDash(row, x);            // Right click: add at canvas X
-      else if (e.button === 2) removeNearestRowDash(row, x, 10); // Left: remove nearest
-      createGrid();
-      return;
-    }
-  }
-
-  // --- Otherwise: grid draw/drag like before ---
-  const c = Math.floor((x - ox) / cellSize);
-  const r = Math.floor((y - oy) / cellSize);
-
-  if (r >= 0 && r < size && c >= 0 && c < size) {
-    isMarking = true;
-    markValue = (e.button === 0) ? 1 : 2;
-    eraseMode = (cellStates[r][c] === markValue);
-
-    currentAction = [];
-    const prevValue = cellStates[r][c];
-    const newValue = eraseMode ? 0 : markValue;
-
-    cellStates[r][c] = newValue;
-    currentAction = [{ row: r, col: c, previous: prevValue, newValue }];
-    createGrid();
-  } else {
-    isDragging = true;
-    dragOffsetX = e.clientX - frame.offsetLeft;
-    dragOffsetY = e.clientY - frame.offsetTop;
-  }
-}
-    function onCanvasMouseMove(e) {
-  const rect = canvas.getBoundingClientRect();
-  const scaleX = canvas.width / rect.width;
-  const scaleY = canvas.height / rect.height;
-  const x = (e.clientX - rect.left) * scaleX;
-  const y = (e.clientY - rect.top) * scaleY;
-
-  const { clueW, clueH, cellSize, ox, oy } = computeGridGeometry();
-
-  // Determine indices if inside grid
-  const c = Math.floor((x - ox) / cellSize);
-  const r = Math.floor((y - oy) / cellSize);
-
-  // Extended hover defaults
-  let newRow = -1, newCol = -1;
-
-  // Row highlight over full vertical grid span, regardless of X (so it works over left clues)
-  const yOverGrid = (y >= oy && y < oy + size * cellSize);
-  if (yOverGrid) {
-    const ry = Math.floor((y - oy) / cellSize);
-    if (ry >= 0 && ry < size) newRow = ry;
-  }
-
-  // Column highlight in top clue band
-  const inTopClues = (x >= ox && x < ox + size * cellSize && y >= oy - clueH && y < oy);
-  if (inTopClues) {
-    const col = Math.floor((x - ox) / cellSize);
-    if (col >= 0 && col < size) newCol = col;
-  }
-
-  // Inside grid gives both
-  if (r >= 0 && r < size && c >= 0 && c < size) {
-    newRow = r;
-    newCol = c;
-  }
-
-  hoveredRow = newRow;
-  hoveredCol = newCol;
-
-  // Drag-paint inside grid
-  if (isMarking && newRow >= 0 && newCol >= 0) {
-    const targetValue = eraseMode ? 0 : markValue;
-    if (cellStates[newRow][newCol] !== targetValue) {
-      if (!currentAction) currentAction = [];
-      currentAction.push({
-        row: newRow, col: newCol,
-        previous: cellStates[newRow][newCol],
-        newValue: targetValue
-      });
-      cellStates[newRow][newCol] = targetValue;
-    }
-  }
-
-  createGrid();
-}
-
-
-    function setupCanvas() {
-        frame = document.createElement('div');
-        frame.id = 'draggable-frame';
-        frame.style.cssText = `
-            position: fixed; top: 20px; left: 20px; background: black;
-            border: 2px solid #555; border-radius: 8px; z-index: 1000;
-        `;
-        canvas = document.createElement('canvas');
-        canvas.id = 'canvas';
-        frame.appendChild(canvas);
-        document.body.appendChild(frame);
-        ctx = canvas.getContext('2d');
-
-        // ─── ALWAYS create “Restore” button, hidden by default ──────────────────
-        const restoreBtn = document.createElement('button');
-        restoreBtn.id = 'restore-button';
-        restoreBtn.textContent = 'Restore nonogram overlay';
-        Object.assign(restoreBtn.style, {
-            position: 'absolute',
-            bottom: '12px',
-            left: '12px',
-            zIndex: '10003',
-            padding: '6px 12px',
-            background: '#00cc44',
-            boxShadow: '0 0 8px #00cc44',
-            color: 'white',
-            fontWeight: 'bold',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            display: 'none'
-        });
-        restoreBtn.onclick = () => restoreCanvas();
-
-        const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
-        if (video && video.parentElement) {
-            video.parentElement.style.position = 'relative';
-            video.parentElement.appendChild(restoreBtn);
-        } else {
-            document.body.appendChild(restoreBtn);
-        }
-        // ────────────────────────────────────────────────────────────────────────
-
-        if (showMinimizeButtons) {
-            minimizeBtn = document.createElement('button');
-            minimizeBtn.textContent = 'X';
-            Object.assign(minimizeBtn.style, {
-                position: 'absolute',
-                top: '4px',
-                left: '4px',
-                width: '24px',
-                height: '24px',
-                fontWeight: 'bold',
-                fontSize: '16px',
-                lineHeight: '22px',
-                textAlign: 'center',
-                zIndex: 10002,
-                background: '#f0f0f0',
-                border: '1px solid #444',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                padding: '0',
-                color: 'black'
-            });
-            minimizeBtn.onclick = minimizeCanvas;
-            frame.appendChild(minimizeBtn);
-        }
-
-canvas.addEventListener('mousedown', onCanvasMouseDown);
-
-        document.addEventListener('mousemove', (e) => {
-            if (isDragging) {
-                frame.style.left = `${e.clientX - dragOffsetX}px`;
-                frame.style.top = `${e.clientY - dragOffsetY}px`;
-            }
-        });
-        document.addEventListener('mouseup', () => {
-            isDragging = false;
-            isMarking = false;
-
-            if (currentAction && currentAction.length) {
-                moveHistory.push(currentAction);
-            }
-            currentAction = null;
-        });
-
-  canvas.addEventListener('mousemove', onCanvasMouseMove);
-
-        canvas.addEventListener('contextmenu', (e) => {
-            e.preventDefault();
-        });
-    }
-
-    function createMainButtons() {
-  // clear monitor before setting new one
-  if (activityBtnMonitorId) {
-    clearInterval(activityBtnMonitorId);
-    activityBtnMonitorId = null;
-  }
-
-
-    const container = document.createElement('div');
-    container.id = 'button-container';
-    container.style.cssText = `
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        display: flex;
-        align-items: center;
-        padding: 6px 8px;
-        z-index: 10001;
-        pointer-events: auto;
-        background: rgba(0,0,0,0.5);
-        border-top: 1px solid #333;
-    `;
-    frame.appendChild(container);
-
-    const makeBtn = (label, onClick) => {
-        const btn = document.createElement('button');
-        btn.textContent = label;
-        btn.style.cssText = `
-            padding: 4px 8px;
-            background: #fff;
-            border: 1px solid #000;
-            border-radius: 3px;
-            font-size: 13px;
-            color: black;
-            cursor: pointer;
-            transition: background 0.15s ease, opacity 0.15s ease;
-        `;
-        btn.onmouseenter = () => btn.style.background = '#f0f0f0';
-        btn.onmouseleave = () => btn.style.background = '#fff';
-        btn.onclick = onClick;
-        return btn;
-    };
-
-    // Left‐aligned buttons
-    exportFillBtn  = container.appendChild(makeBtn('Export !fill',  exportCells));
-    exportEmptyBtn = container.appendChild(makeBtn('Export !empty', exportWhiteCells));
-    container.appendChild(makeBtn('Undo', () => {
-        if (!moveHistory.length) return;
-        const lastAction = moveHistory.pop();
-        lastAction.forEach(({ row, col, previous, newValue }) => {
-            const coord = `${String.fromCharCode(97 + col)}${row + 1}`;
-            if (newValue === 1) lastExported.delete(coord);
-            if (newValue === 2) lastExportedWhite.delete(coord);
-            cellStates[row][col] = previous;
-        });
-        createGrid();
-    }));
-
-    // Spacer pushes the next buttons to the right
-    const spacer = document.createElement('div');
-    spacer.style.flex = '1';
-    container.appendChild(spacer);
-
-    // Right‐aligned buttons
-    container.appendChild(makeBtn('reset export', exportAllCells));
-    container.appendChild(makeBtn('Clean grid', cleanAll));
-    container.appendChild(makeBtn('⚙️ Config', () => {
-        toggleExtraConfigPanel();
-    }));
-
-    // ---- Activity Coupon button (special behaviour) ----
-    const activityBtn = makeBtn('🎟️ Activity Coupon', async () => {
-        if (activityBtn.disabled) return;
-        try {
-            activityBtn.disabled = true;
-            activityBtn.style.opacity = '0.7';
-            activityBtn.textContent = '⏳ Redeeming...';
-            await redeemAndTrack(); // uses attemptRedeemCycle() and records timestamp
-        } catch (e) {
-            console.error('Redeem error:', e);
-        } finally {
-            // restore text (icon + label)
-            activityBtn.textContent = '🎟️ Activity Coupon';
-            activityBtn.disabled = false;
-            activityBtn.style.opacity = '1';
-            // start periodic monitor for the activity button
-            updateActivityBtnStyle(activityBtn);
-            activityBtnMonitorId = setInterval(() => {
-                updateActivityBtnStyle(activityBtn);
-            }, 30_000);
-        }
+      }
     });
+    const minLabel = document.createElement('label');
+    minLabel.htmlFor = 'chk-minimize';
+    minLabel.textContent = 'Enable minimize/restore';
+    minDiv.appendChild(minChk);
+    minDiv.appendChild(minLabel);
 
-    // override hover handlers to respect alert state
-    activityBtn.onmouseenter = () => {
-        const state = activityBtn.dataset.alert;
-        if (!state) activityBtn.style.background = '#f0f0f0';
-        else if (state === 'warning') activityBtn.style.background = '#ff2a2a';
-        else if (state === 'overdue') activityBtn.style.background = '#8b1a1a';
+    const blueDiv = document.createElement('div');
+    blueDiv.style.marginTop = '8px';
+    const blueChk = document.createElement('input');
+    blueChk.type = 'checkbox';
+    blueChk.id = 'chk-bluefill';
+    blueChk.checked = state.useBlueFill;
+    blueChk.style.marginRight = '6px';
+    blueChk.addEventListener('change', () => {
+      state.useBlueFill = blueChk.checked;
+      state.uiConfig.useBlueFill = state.useBlueFill;
+      saveUIConfig();
+      createGridRef();
+    });
+    const blueLabel = document.createElement('label');
+    blueLabel.htmlFor = 'chk-bluefill';
+    blueLabel.textContent = 'Use blue fill color';
+    blueDiv.appendChild(blueChk);
+    blueDiv.appendChild(blueLabel);
+
+    const statusDivToggle = document.createElement('div');
+    statusDivToggle.style.marginTop = '8px';
+    const statusChk = document.createElement('input');
+    statusChk.type = 'checkbox';
+    statusChk.id = 'chk-status';
+    statusChk.checked = state.statusEnabled;
+    statusChk.style.marginRight = '6px';
+    statusChk.addEventListener('change', () => {
+      state.statusEnabled = statusChk.checked;
+      state.uiConfig.statusEnabled = state.statusEnabled;
+      saveUIConfig();
+      const scCont = document.getElementById('status-container');
+      if (scCont) scCont.style.display = state.statusEnabled ? 'block' : 'none';
+    });
+    const statusLabel = document.createElement('label');
+    statusLabel.htmlFor = 'chk-status';
+    statusLabel.textContent = 'Status canvas';
+    statusDivToggle.appendChild(statusChk);
+    statusDivToggle.appendChild(statusLabel);
+
+    const autosendDiv = document.createElement('div');
+    autosendDiv.style.marginTop = '8px';
+    const autosendChk = document.createElement('input');
+    autosendChk.type = 'checkbox';
+    autosendChk.id = 'chk-autosend';
+    autosendChk.checked = state.autosendEnabled;
+    autosendChk.style.marginRight = '6px';
+    autosendChk.addEventListener('change', () => {
+      state.autosendEnabled = autosendChk.checked;
+      state.uiConfig.autosendEnabled = state.autosendEnabled;
+      saveUIConfig();
+      if (state.autosendEnabled) {
+        ensureSendLoop();
+        ensureProgressLoop();
+      } else {
+        stopProgressLoop();
+      }
+    });
+    const autosendLabel = document.createElement('label');
+    autosendLabel.htmlFor = 'chk-autosend';
+    autosendLabel.textContent = 'Auto-send chat commands';
+    autosendDiv.appendChild(autosendChk);
+    autosendDiv.appendChild(autosendLabel);
+
+    const fineDiv = document.createElement('div');
+    fineDiv.style.marginTop = '8px';
+    const fineChk = document.createElement('input');
+    fineChk.type = 'checkbox';
+    fineChk.id = 'chk-fine';
+    fineChk.checked = state.fineTuningEnabled;
+    fineChk.style.marginRight = '6px';
+    fineChk.addEventListener('change', () => {
+      state.fineTuningEnabled = fineChk.checked;
+      state.uiConfig.fineTuningEnabled = state.fineTuningEnabled;
+      saveUIConfig();
+      const fineSection = document.getElementById('section-fine');
+      if (fineSection) {
+        fineSection.style.display = state.fineTuningEnabled ? 'block' : 'none';
+      }
+    });
+    const fineLabel = document.createElement('label');
+    fineLabel.htmlFor = 'chk-fine';
+    fineLabel.textContent = 'Enable fine-tune controls';
+    fineDiv.appendChild(fineChk);
+    fineDiv.appendChild(fineLabel);
+
+    const sharpenDiv = document.createElement('div');
+    sharpenDiv.style.marginTop = '8px';
+    const sharpenChk = document.createElement('input');
+    sharpenChk.type = 'checkbox';
+    sharpenChk.id = 'chk-sharpen';
+    sharpenChk.checked = state.sharpeningEnabled;
+    sharpenChk.style.marginRight = '6px';
+    sharpenChk.addEventListener('change', () => {
+      state.sharpeningEnabled = sharpenChk.checked;
+      state.uiConfig.sharpeningEnabled = state.sharpeningEnabled;
+      saveUIConfig();
+    });
+    const sharpenLabel = document.createElement('label');
+    sharpenLabel.htmlFor = 'chk-sharpen';
+    sharpenLabel.textContent = 'Enable sharpen filter';
+    sharpenDiv.appendChild(sharpenChk);
+    sharpenDiv.appendChild(sharpenLabel);
+
+    const guardDiv = document.createElement('div');
+    guardDiv.style.marginTop = '8px';
+    const guardChk = document.createElement('input');
+    guardChk.type = 'checkbox';
+    guardChk.id = 'chk-guard';
+    guardChk.checked = state.guard_Export;
+    guardChk.addEventListener('change', () => {
+      state.guard_Export = guardChk.checked;
+      state.uiConfig.guardExport = state.guard_Export;
+      localStorage.setItem('nonogramUIConfig', JSON.stringify(state.uiConfig));
+      console.log('[Reward Redeemer] Guard export set to', state.guard_Export);
+    });
+    const guardLabel = document.createElement('label');
+    guardLabel.htmlFor = 'chk-guard';
+    guardLabel.textContent = 'Coupon auto-redeem before sending commands';
+    guardDiv.appendChild(guardChk);
+    guardDiv.appendChild(guardLabel);
+
+    panel.appendChild(autosendDiv);
+    panel.appendChild(guardDiv);
+    panel.appendChild(minDiv);
+    panel.appendChild(blueDiv);
+    panel.appendChild(statusDivToggle);
+    panel.appendChild(fineDiv);
+    panel.appendChild(sharpenDiv);
+
+    state.frame.appendChild(panel);
+  }
+
+  function toggleExtraConfigPanel() {
+    const panel = document.getElementById('extra-config-panel');
+    if (!panel) return;
+    panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+  }
+
+  function createConfigPanel() {
+    if (document.getElementById('config-panel')) return;
+    const panel = document.createElement('div');
+    panel.id = 'config-panel';
+    panel.style.cssText = `
+    position: fixed;
+    top: 60px;
+    left: 60px;
+    background: #fff;
+    padding: 12px;
+    border: 1px solid #000;
+    border-radius: 6px;
+    z-index: 10002;
+    display: none;
+    color: black;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: 1.6em;
+  `;
+    panel.innerHTML = `
+    <label>Size: <input id="cfg-size" type="number" value="${state.size}" /></label><br/>
+    <label>Col Clues: <input id="cfg-cols" type="number" value="${state.colClueCount}" /></label><br/>
+    <label>Fine Tune: <input id="cfg-fine" type="number" value="${state.fineTune}" /></label><br/>
+    <label>Anchor X: <input id="cfg-anchorX" type="number" value="${state.anchorX}" /></label><br/>
+    <label>Anchor Y: <input id="cfg-anchorY" type="number" value="${state.anchorY}" /></label><br/>
+    <button id="cfg-apply">Apply</button>
+    <button id="cfg-close">Close</button>
+  `;
+    document.body.appendChild(panel);
+
+    panel.querySelector('#cfg-apply').onclick = () => {
+      state.size = +panel.querySelector('#cfg-size').value;
+      state.colClueCount = +panel.querySelector('#cfg-cols').value;
+      state.fineTune = +panel.querySelector('#cfg-fine').value;
+      state.anchorX = +panel.querySelector('#cfg-anchorX').value;
+      state.anchorY = +panel.querySelector('#cfg-anchorY').value;
+      saveLayout();
+      initCells();
+      updateCanvasSizeRef();
     };
-    activityBtn.onmouseleave = () => {
-        updateActivityBtnStyle(activityBtn);
+
+    panel.querySelector('#cfg-close').onclick = () => {
+      panel.style.display = 'none';
     };
+  }
 
-    // helper to set the activity button style based on minutes since last redeem
-    function updateActivityBtnStyle(btn) {
-        const mins = (typeof minutesSinceRedeem === 'function') ? minutesSinceRedeem() : Infinity;
-
-        // default (fresh): white background, black text, normal border
-        if (isNaN(mins) || mins < 30) {
-            btn.dataset.alert = '';
-            btn.style.background = '#fff';
-            btn.style.color = 'black';
-            btn.style.border = '1px solid #000';
-        }
-        // warning zone: 30–45 minutes
-        else if (mins >= 30 && mins <= 45) {
-            btn.dataset.alert = 'warning';
-            btn.style.background = '#ff4444';
-            btn.style.color = 'white';
-            btn.style.border = '1px solid #cc0000';
-        }
-        // overdue: >45 minutes
-        else {
-            btn.dataset.alert = 'overdue';
-            btn.style.background = '#b22222';
-            btn.style.color = 'white';
-            btn.style.border = '1px solid #800000';
-        }
-    }
-
-  // append activity button last (right side)
-    container.appendChild(activityBtn);
-
-    // start periodic monitor for the activity button
-    updateActivityBtnStyle(activityBtn); // immediate update
-    activityBtnMonitorId = setInterval(() => {
-        updateActivityBtnStyle(activityBtn);
-    }, 30_000);
-}
-
-
-    let labelMap = {};
-    let controlSections = [];
-    function createControlPanel() {
-        const controlContainer = document.createElement('div');
-        controlContainer.id = 'control-container';
-        Object.assign(controlContainer.style, {
-            position: 'absolute',
-            right: '-160px',
-            top: '0',
-            zIndex: '10001',
-            padding: '8px',
-            background: '#fff',
-            border: '1px solid #000',
-            borderRadius: '4px',
-            boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
-            lineHeight: '1.4em',
-            color: 'black',
-            width: '160px'
-        });
-
-        frame.appendChild(controlContainer);
-
-        labelMap = {};
-        controlSections = [
-            {
-                key: 'size', label: 'Grid size',
-                get: () => size,
-                dec: () => { disableShrinks(); size = Math.max(1, size - 1); loadLayout(); initCells(); updateCanvasSize(); updateAllLabels(); },
-                inc: () => { disableShrinks(); size++; loadLayout(); initCells(); updateCanvasSize(); updateAllLabels(); }
-            },
-            {
-                key: 'cols', label: 'Col clues',
-                get: () => colClueCount,
-                dec: () => { disableShrinks(); colClueCount = Math.max(1, colClueCount - 1); loadLayout(); initCells(); updateCanvasSize(); updateAllLabels(); },
-                inc: () => { disableShrinks(); colClueCount++; loadLayout(); initCells(); updateCanvasSize(); updateAllLabels(); }
-            },
-            {
-                key: 'fine', label: 'Fine tune',
-                get: () => fineTune,
-                dec: () => { disableShrinks(); fineTune--; saveLayout(); updateCanvasSize(); updateAllLabels(); },
-                inc: () => { disableShrinks(); fineTune++; saveLayout(); updateCanvasSize(); updateAllLabels(); }
-            }
-        ];
-
-        controlSections.forEach((s, i) => {
-            const sec = document.createElement('div');
-            sec.id = `section-${s.key}`;
-            if (s.key === 'fine' && !fineTuningEnabled) {
-                sec.style.display = 'none';
-            }
-
-            const lbl = document.createElement('div');
-            lbl.textContent = `${s.label}: ${s.get()}`;
-            labelMap[s.key] = lbl;
-            lbl.style.fontWeight = 'bold';
-            lbl.style.marginBottom = '4px';
-            sec.appendChild(lbl);
-
-            const row = document.createElement('div');
-            Object.assign(row.style, {
-                display: 'flex',
-                gap: '4px',
-                marginBottom: '8px',
-                alignItems: 'center'
-            });
-
-            [['−', s.dec], ['+', s.inc]].forEach(([symbol, fn]) => {
-                const btn = document.createElement('button');
-                btn.textContent = symbol;
-                Object.assign(btn.style, {
-                    width: '28px',
-                    height: '28px',
-                    border: '1px solid #007bff',
-                    borderRadius: '4px',
-                    fontSize: '16px',
-                    cursor: 'pointer',
-                    backgroundColor: '#007bff',
-                    color: 'white',
-                    textAlign: 'center'
-                });
-                btn.addEventListener('click', () => {
-                    fn();
-                    lbl.textContent = `${s.label}: ${s.get()}`;
-                });
-                row.appendChild(btn);
-            });
-
-            if (s.key === 'size') {
-                const spacer = document.createElement('div');
-                spacer.style.flex = '1';
-                row.appendChild(spacer);
-
-                const resetBtn = document.createElement('button');
-                resetBtn.textContent = '4';
-                Object.assign(resetBtn.style, {
-                    width: '28px',
-                    height: '28px',
-                    border: '1px solid #28a745',
-                    borderRadius: '4px',
-                    fontSize: '16px',
-                    cursor: 'pointer',
-                    backgroundColor: '#28a745',
-                    color: 'white',
-                    textAlign: 'center'
-                });
-                resetBtn.addEventListener('click', () => {
-                    saveLayout();
-                    size = 4;
-                    rowClueCount = 1;
-                    colClueCount = 1;
-                    initCells();
-                    updateCanvasSize();
-                    lbl.textContent = `${s.label}: ${s.get()}`;
-                });
-                row.appendChild(resetBtn);
-            }
-
-            if (s.key === 'cols') {
-                const spacer = document.createElement('div');
-                spacer.style.flex = '1';
-                row.appendChild(spacer);
-
-                exportDartBtn = document.createElement('button');
-                exportDartBtn.textContent = '🎯';
-                Object.assign(exportDartBtn.style, {
-                    width: '28px',
-                    height: '28px',
-                    border: '1px solid #D6B1AA',
-                    borderRadius: '4px',
-                    fontSize: '16px',
-                    cursor: 'pointer',
-                    backgroundColor: '#FFFFFF',
-                    color: 'white',
-                    textAlign: 'center'
-                });
-                exportDartBtn.addEventListener('click', exportDartCommand);
-                row.appendChild(exportDartBtn);
-            }
-
-            sec.appendChild(row);
-            controlContainer.appendChild(sec);
-            if (i < controlSections.length - 1) controlContainer.appendChild(document.createElement('hr'));
-        });
-
-        // ─── MAGNIFICATION SECTION ────────────────────────────────────────────────
-        const magSec = document.createElement('div');
-        magSec.id = 'section-zoom';
-
-        const magLbl = document.createElement('div');
-        magLbl.textContent = 'Magnification';
-        magLbl.style.fontWeight = 'bold';
-        magLbl.style.marginBottom = '4px';
-        magSec.appendChild(magLbl);
-
-        const magRow = document.createElement('div');
-        Object.assign(magRow.style, {
-            display: 'flex',
-            gap: '4px',
-            marginBottom: '8px',
-            alignItems: 'center'
-        });
-
-        const makeZoomBtn = (label, onClick) => {
-            const btn = document.createElement('button');
-            btn.textContent = label;
-            Object.assign(btn.style, {
-                width: '28px',
-                height: '28px',
-                border: '1px solid #007bff',
-                borderRadius: '4px',
-                fontSize: '16px',
-                cursor: 'pointer',
-                backgroundColor: '#007bff',
-                color: 'white',
-                textAlign: 'center'
-            });
-            btn.addEventListener('click', onClick);
-            return btn;
-        };
-
-        magRow.appendChild(makeZoomBtn('−', () => {
-            zoomFactor = Math.max(0.1, zoomFactor * 0.9);
-            updateCanvasSize();
-        }));
-        magRow.appendChild(makeZoomBtn('+', () => {
-            zoomFactor = zoomFactor * 1.1;
-            updateCanvasSize();
-        }));
-
-        magSec.appendChild(magRow);
-        controlContainer.appendChild(magSec);
-    }
-
-    function updateAllLabels() {
-        Object.entries(labelMap).forEach(([k, lbl]) => {
-            const section = controlSections.find(s => s.key === k);
-            if (section) lbl.textContent = `${section.label}: ${section.get()}`;
-        });
-    }
-
-    //
-    // ─── EXTRA CONFIG PANEL ───────────────────────────────────────────────────────
-    //
-    function createExtraConfigPanel() {
-        if (document.getElementById('extra-config-panel')) return;
-
-        const panel = document.createElement('div');
-        panel.id = 'extra-config-panel';
-        panel.style.cssText = `
-        position: absolute;
-        top: 40px;
-        left: 0;
-        background: #f9f9f9;
-        padding: 12px;
-        border: 1px solid #333;
-        border-radius: 6px;
-        z-index: 10002;
-        display: none;
-        color: black;
-        font-size: 14px;
-        width: 200px;
-    `;
-
-        // 1) Minimize toggle
-        const minDiv = document.createElement('div');
-        const minChk = document.createElement('input');
-        minChk.type = 'checkbox';
-        minChk.id = 'chk-minimize';
-        minChk.checked = showMinimizeButtons;
-        minChk.style.marginRight = '6px';
-        minChk.addEventListener('change', () => {
-            showMinimizeButtons = minChk.checked;
-            uiConfig.showMinimizeButtons = showMinimizeButtons;
-            saveUIConfig();
-            if (showMinimizeButtons) {
-                if (!minimizeBtn && !isMinimized) {
-                    minimizeBtn = document.createElement('button');
-                    minimizeBtn.textContent = 'X';
-                    Object.assign(minimizeBtn.style, {
-                        position: 'absolute',
-                        top: '4px',
-                        left: '4px',
-                        width: '24px',
-                        height: '24px',
-                        fontWeight: 'bold',
-                        fontSize: '16px',
-                        lineHeight: '22px',
-                        textAlign: 'center',
-                        zIndex: 10002,
-                        background: '#f0f0f0',
-                        border: '1px solid #444',
-                        borderRadius: '4px',
-                        cursor: 'pointer',
-                        padding: '0',
-                        color: 'black'
-                    });
-                    minimizeBtn.onclick = minimizeCanvas;
-                    frame.appendChild(minimizeBtn);
-                }
-            } else {
-                if (minimizeBtn && minimizeBtn.parentElement) {
-                    minimizeBtn.remove();
-                    minimizeBtn = null;
-                }
-                const restoreBtn = document.getElementById('restore-button');
-                if (restoreBtn) restoreBtn.style.display = 'none';
-            }
-        });
-        const minLabel = document.createElement('label');
-        minLabel.htmlFor = 'chk-minimize';
-        minLabel.textContent = 'Enable minimize/restore';
-        minDiv.appendChild(minChk);
-        minDiv.appendChild(minLabel);
-
-        // 2) Blue fill toggle
-        const blueDiv = document.createElement('div');
-        blueDiv.style.marginTop = '8px';
-        const blueChk = document.createElement('input');
-        blueChk.type = 'checkbox';
-        blueChk.id = 'chk-bluefill';
-        blueChk.checked = useBlueFill;
-        blueChk.style.marginRight = '6px';
-        blueChk.addEventListener('change', () => {
-            useBlueFill = blueChk.checked;
-            uiConfig.useBlueFill = useBlueFill;
-            saveUIConfig();
-            createGrid();
-        });
-        const blueLabel = document.createElement('label');
-        blueLabel.htmlFor = 'chk-bluefill';
-        blueLabel.textContent = 'Use blue fill color';
-        blueDiv.appendChild(blueChk);
-        blueDiv.appendChild(blueLabel);
-
-        // 3) Status-canvas toggle
-        const statusDivToggle = document.createElement('div');
-        statusDivToggle.style.marginTop = '8px';
-        const statusChk = document.createElement('input');
-        statusChk.type = 'checkbox';
-        statusChk.id = 'chk-status';
-        statusChk.checked = statusEnabled;
-        statusChk.style.marginRight = '6px';
-        statusChk.addEventListener('change', () => {
-            statusEnabled = statusChk.checked;
-            uiConfig.statusEnabled = statusEnabled;
-            saveUIConfig();
-            const scCont = document.getElementById('status-container');
-            if (scCont) scCont.style.display = statusEnabled ? 'block' : 'none';
-        });
-        const statusLabel = document.createElement('label');
-        statusLabel.htmlFor = 'chk-status';
-        statusLabel.textContent = 'Status canvas';
-        statusDivToggle.appendChild(statusChk);
-        statusDivToggle.appendChild(statusLabel);
-
-        // 4) Auto-send toggle (no OAuth)  ← NEW
-        const autosendDiv = document.createElement('div');
-        autosendDiv.style.marginTop = '8px';
-        const autosendChk = document.createElement('input');
-        autosendChk.type = 'checkbox';
-        autosendChk.id = 'chk-autosend';
-        autosendChk.checked = autosendEnabled; // requires: let autosendEnabled = uiConfig.autosendEnabled ?? false;
-        autosendChk.style.marginRight = '6px';
-        autosendChk.addEventListener('change', () => {
-            autosendEnabled = autosendChk.checked;
-            uiConfig.autosendEnabled = autosendEnabled;
-            saveUIConfig();
-
-            if (autosendEnabled) {
-                // Start queue + cooldown progress loops
-                if (typeof ensureSendLoop === 'function') ensureSendLoop();
-                if (typeof ensureProgressLoop === 'function') ensureProgressLoop();
-            } else {
-                // Stop/clear the progress UI
-                if (typeof stopProgressLoop === 'function') stopProgressLoop();
-            }
-        });
-        const autosendLabel = document.createElement('label');
-        autosendLabel.htmlFor = 'chk-autosend';
-        autosendLabel.textContent = 'Auto-send chat commands';
-        autosendDiv.appendChild(autosendChk);
-        autosendDiv.appendChild(autosendLabel);
-
-        // 5) Fine-tuning toggle
-        const fineDiv = document.createElement('div');
-        fineDiv.style.marginTop = '8px';
-        const fineChk = document.createElement('input');
-        fineChk.type = 'checkbox';
-        fineChk.id = 'chk-fine';
-        fineChk.checked = fineTuningEnabled;
-        fineChk.style.marginRight = '6px';
-        fineChk.addEventListener('change', () => {
-            fineTuningEnabled = fineChk.checked;
-            uiConfig.fineTuningEnabled = fineTuningEnabled;
-            saveUIConfig();
-            const fineSection = document.getElementById('section-fine');
-            if (fineSection) {
-                fineSection.style.display = fineTuningEnabled ? 'block' : 'none';
-            }
-        });
-        const fineLabel = document.createElement('label');
-        fineLabel.htmlFor = 'chk-fine';
-        fineLabel.textContent = 'Enable fine-tune controls';
-        fineDiv.appendChild(fineChk);
-        fineDiv.appendChild(fineLabel);
-
-        // 6) Sharpen toggle
-        const sharpenDiv = document.createElement('div');
-        sharpenDiv.style.marginTop = '8px';
-        const sharpenChk = document.createElement('input');
-        sharpenChk.type = 'checkbox';
-        sharpenChk.id = 'chk-sharpen';
-        sharpenChk.checked = sharpeningEnabled;
-        sharpenChk.style.marginRight = '6px';
-        sharpenChk.addEventListener('change', () => {
-            sharpeningEnabled = sharpenChk.checked;
-            uiConfig.sharpeningEnabled = sharpeningEnabled;
-            saveUIConfig();
-        });
-        const sharpenLabel = document.createElement('label');
-        sharpenLabel.htmlFor = 'chk-sharpen';
-        sharpenLabel.textContent = 'Enable sharpen filter';
-        sharpenDiv.appendChild(sharpenChk);
-        sharpenDiv.appendChild(sharpenLabel);
-        // 7) Guard Export toggle
-        const guardDiv = document.createElement('div');
-        guardDiv.style.marginTop = '8px';
-
-        const guardChk = document.createElement('input');
-        guardChk.type = 'checkbox';
-        guardChk.id = 'chk-guard';
-        guardChk.checked = guard_Export;  // load from config
-
-        guardChk.addEventListener('change', () => {
-            guard_Export = guardChk.checked;       // update variable
-            uiConfig.guardExport = guard_Export;   // sync to config
-            localStorage.setItem('nonogramUIConfig', JSON.stringify(uiConfig)); // persist
-            console.log("[Reward Redeemer] Guard export set to", guard_Export);
-        });
-
-        const guardLabel = document.createElement('label');
-        guardLabel.htmlFor = 'chk-guard';
-        guardLabel.textContent = 'Coupon auto-redeem before sending commands';
-
-        guardDiv.appendChild(guardChk);
-        guardDiv.appendChild(guardLabel);
-
-        // Add it to panel
-        panel.appendChild(autosendDiv); // ← NEW placement
-        panel.appendChild(guardDiv);
-        // Assemble in order
-        panel.appendChild(minDiv);
-        panel.appendChild(blueDiv);
-        panel.appendChild(statusDivToggle);
-
-        panel.appendChild(fineDiv);
-        panel.appendChild(sharpenDiv);
-
-        frame.appendChild(panel);
-    }
-
-    function toggleExtraConfigPanel() {
-        const panel = document.getElementById('extra-config-panel');
-        if (!panel) return;
-        panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
-    }
-
-    function createConfigPanel() {
-        if (document.getElementById('config-panel')) return;
-        const panel = document.createElement('div');
-        panel.id = 'config-panel';
-        panel.style.cssText = `
-            position: fixed;
-            top: 60px;
-            left: 60px;
-            background: #fff;
-            padding: 12px;
-            border: 1px solid #000;
-            border-radius: 6px;
-            z-index: 10002;
-            display: none;
-            color: black;
-            font-size: 15px;
-            font-weight: bold;
-            line-height: 1.6em;
-        `;
-        panel.innerHTML = `
-            <label>Size: <input id="cfg-size" type="number" value="${size}" /></label><br/>
-            <label>Col Clues: <input id="cfg-cols" type="number" value="${colClueCount}" /></label><br/>
-            <label>Fine Tune: <input id="cfg-fine" type="number" value="${fineTune}" /></label><br/>
-            <label>Anchor X: <input id="cfg-anchorX" type="number" value="${anchorX}" /></label><br/>
-            <label>Anchor Y: <input id="cfg-anchorY" type="number" value="${anchorY}" /></label><br/>
-            <button id="cfg-apply">Apply</button>
-            <button id="cfg-close">Close</button>
-        `;
-        document.body.appendChild(panel);
-
-        panel.querySelector('#cfg-apply').onclick = () => {
-            size = +panel.querySelector('#cfg-size').value;
-            colClueCount = +panel.querySelector('#cfg-cols').value;
-            fineTune = +panel.querySelector('#cfg-fine').value;
-            anchorX = +panel.querySelector('#cfg-anchorX').value;
-            anchorY = +panel.querySelector('#cfg-anchorY').value;
-            saveLayout();
-            initCells();
-            updateCanvasSize();
-        };
-
-        panel.querySelector('#cfg-close').onclick = () => {
-            panel.style.display = 'none';
-        };
-    }
-
-    //
-    // ─── STATUS CONTAINER (three small canvases below control‐panel) ─────────────
-    //
-function createStatusContainer() {
+  function createStatusContainer() {
     if (document.getElementById('status-container')) return;
     const controlContainer = document.getElementById('control-container');
     if (!controlContainer) return;
@@ -1982,84 +1488,527 @@ function createStatusContainer() {
     const scCont = document.createElement('div');
     scCont.id = 'status-container';
     scCont.style.cssText = `
-        display: none;
-        margin-top: 8px;
-        width: 100%;
-        text-align: center;
-    `;
+    display: none;
+    margin-top: 8px;
+    width: 100%;
+    text-align: center;
+  `;
 
-    // match original sizing logic (small preview boxes)
-    const cw = Math.max(40, controlContainer.clientWidth - 20); // keep sane min
-    const ch = Math.round((cw * 80) / 250); // original aspect
-
+    const cw = Math.max(40, controlContainer.clientWidth - 20);
+    const ch = Math.round((cw * 80) / 250);
     const cmds = ['!eat', '!sleep', '!play'];
 
+    state.statusCanvases = [];
+
     statusRegions.forEach((region, idx) => {
-        const sc = document.createElement('canvas');
-        sc.id = `status-canvas-${idx}`;
+      const sc = document.createElement('canvas');
+      sc.id = `status-canvas-${idx}`;
+      sc.width = cw;
+      sc.height = ch;
+      sc.style.cssText = `
+      display: inline-block;
+      margin: 4px;
+      width: ${cw}px;
+      height: ${ch}px;
+      border: 1px solid #333;
+      background: black;
+      cursor: pointer;
+      box-sizing: content-box;
+    `;
 
-        // intrinsic drawing size (important!)
-        sc.width = cw;
-        sc.height = ch;
+      const sctx = sc.getContext('2d');
+      sc.addEventListener('click', () => {
+        let cmd = cmds[idx] || '';
+        if (!cmd) return;
+        if (state.statusAltCmd) cmd = cmd + 's';
+        console.log(`[StatusCanvas] clicked index=${idx}, sending ${cmd}`);
+        try {
+          send_message_with_event(cmd);
+          state.statusAltCmd = !state.statusAltCmd;
+        } catch (e) {
+          console.error('Failed to send status command:', e);
+        }
+      });
 
-        // match CSS display size to intrinsic size to avoid stretching
-        sc.style.cssText = `
-            display: inline-block;
-            margin: 4px;
-            width: ${cw}px;
-            height: ${ch}px;
-            border: 1px solid #333;
-            background: black;
-            cursor: pointer;
-            box-sizing: content-box;
-        `;
-
-        const sctx = sc.getContext('2d');
-
-        // sensible click handler that uses your existing chat sender
-        sc.addEventListener('click', (ev) => {
-            let cmd = cmds[idx] || '';
-            if (!cmd) return;
-            if (statusAltCmd) cmd = cmd + 's';
-            console.log(`[StatusCanvas] clicked index=${idx}, sending ${cmd}`);
-            try {
-                send_message_with_event(cmd);
-                statusAltCmd = !statusAltCmd;
-            } catch (e) {
-                console.error('Failed to send status command:', e);
-            }
-        });
-
-        scCont.appendChild(sc);
-        statusCanvases.push({ canvas: sc, ctx: sctx, region });
+      scCont.appendChild(sc);
+      state.statusCanvases.push({ canvas: sc, ctx: sctx, region });
     });
 
     controlContainer.appendChild(scCont);
-    scCont.style.display = statusEnabled ? 'block' : 'none';
-}
+    scCont.style.display = state.statusEnabled ? 'block' : 'none';
+  }
 
-    function createControlAndStatus() {
-        createControlPanel();
-        createStatusContainer();
+  function createControlAndStatus() {
+    createControlPanel();
+    createStatusContainer();
+  }
+
+  // Manages the overlay frame, canvas rendering, ROI capture, and main action buttons.
+
+  function sharpen(ctx, w, h, mix) {
+    let x;
+    let sx;
+    let sy;
+    let r;
+    let g;
+    let b;
+    let a;
+    let dstOff;
+    let srcOff;
+    let wt;
+    let cx;
+    let cy;
+    let scy;
+    let scx;
+    const weights = [0, -1, 0, -1, 5, -1, 0, -1, 0];
+    const katet = Math.round(Math.sqrt(weights.length));
+    const half = (katet * 0.5) | 0;
+    const dstData = ctx.createImageData(w, h);
+    const dstBuff = dstData.data;
+    const srcBuff = ctx.getImageData(0, 0, w, h).data;
+    let y = h;
+
+    while (y--) {
+      x = w;
+      while (x--) {
+        sy = y;
+        sx = x;
+        dstOff = (y * w + x) * 4;
+        r = g = b = a = 0;
+
+        for (cy = 0; cy < katet; cy++) {
+          for (cx = 0; cx < katet; cx++) {
+            scy = sy + cy - half;
+            scx = sx + cx - half;
+            if (scy >= 0 && scy < h && scx >= 0 && scx < w) {
+              srcOff = (scy * w + scx) * 4;
+              wt = weights[cy * katet + cx];
+              r += srcBuff[srcOff] * wt;
+              g += srcBuff[srcOff + 1] * wt;
+              b += srcBuff[srcOff + 2] * wt;
+              a += srcBuff[srcOff + 3] * wt;
+            }
+          }
+        }
+
+        dstBuff[dstOff] = r * mix + srcBuff[dstOff] * (1 - mix);
+        dstBuff[dstOff + 1] = g * mix + srcBuff[dstOff + 1] * (1 - mix);
+        dstBuff[dstOff + 2] = b * mix + srcBuff[dstOff + 2] * (1 - mix);
+        dstBuff[dstOff + 3] = srcBuff[dstOff + 3];
+      }
     }
 
-    window.addEventListener('load', () => {
-        setupCanvas();
-        initCells();
-        createStatusContainer()
-        updateCanvasSize();
-        createMainButtons();
-        createConfigPanel();
-        createControlAndStatus();
-        createExtraConfigPanel();
-        if (autosendEnabled) {
-            // show “Ready” state right away
-            nextSendAt = Date.now();
-            ensureProgressLoop();
-            // send loop starts itself when there’s something in the queue
-        }
-        render();
-        setInterval(updateROI, 1000); // update ROI once per second
+    ctx.putImageData(dstData, 0, 0);
+  }
+
+  function updateROI() {
+    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    if (!video) return;
+
+    state.roiCtx.clearRect(0, 0, state.roiCanvas.width, state.roiCanvas.height);
+
+    const actualWidth = video.videoWidth;
+    const actualHeight = video.videoHeight;
+    const roiWidth = actualWidth * state.roiWidthPercent;
+    const roiHeight = actualHeight * state.roiHeightPercent;
+    const roiX = actualWidth - roiWidth;
+    const roiY = actualHeight - roiHeight;
+
+    state.roiCtx.drawImage(video, roiX, roiY, roiWidth, roiHeight, 0, 0, state.roiCanvas.width, state.roiCanvas.height);
+
+    if (state.sharpeningEnabled) {
+      sharpen(state.roiCtx, state.roiCanvas.width, state.roiCanvas.height, 0.9);
+    }
+  }
+
+  function drawStatus() {
+    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    if (!video) return;
+
+    const actualWidth = video.videoWidth;
+    const actualHeight = video.videoHeight;
+    const scaleX = actualWidth / 1920;
+    const scaleY = actualHeight / 1080;
+
+    state.statusCanvases.forEach(({ canvas: sc, ctx: sctx, region }) => {
+      const sx = region.sx * scaleX;
+      const sy = region.sy * scaleY;
+      const sw = region.sw * scaleX;
+      const sh = region.sh * scaleY;
+      sctx.clearRect(0, 0, sc.width, sc.height);
+      sctx.drawImage(video, sx, sy, sw, sh, 0, 0, sc.width, sc.height);
     });
+  }
+
+  function render() {
+    if (state.isMinimized || state.canvas.style.display === 'none') {
+      return;
+    }
+
+    state.ctx.clearRect(0, 0, state.canvas.width, state.canvas.height);
+    state.ctx.drawImage(state.roiCanvas, 0, 0);
+    createGrid();
+    if (state.statusEnabled) drawStatus();
+
+    if (!document.hidden) {
+      state.renderHandle = requestAnimationFrame(render);
+    } else {
+      state.renderHandle = setTimeout(render, 1000 / 30);
+    }
+  }
+
+  function minimizeCanvas() {
+    state.isMinimized = true;
+    clearRenderHandle();
+
+    state.canvas.style.display = 'none';
+    state.frame.style.height = '0px';
+    state.frame.style.width = '0px';
+
+    const ctrl = document.getElementById('control-container');
+    if (ctrl) ctrl.style.display = 'none';
+
+    const btns = document.getElementById('button-container');
+    if (btns) btns.style.display = 'none';
+
+    const cfg = document.getElementById('config-panel');
+    if (cfg) cfg.style.display = 'none';
+
+    const extraCfg = document.getElementById('extra-config-panel');
+    if (extraCfg) extraCfg.style.display = 'none';
+
+    const statusCont = document.getElementById('status-container');
+    if (statusCont) statusCont.style.display = 'none';
+
+    const restoreBtn = document.getElementById('restore-button');
+    if (restoreBtn) restoreBtn.style.display = 'block';
+
+    if (state.minimizeBtn && state.minimizeBtn.parentElement) {
+      state.minimizeBtn.remove();
+      state.minimizeBtn = null;
+    }
+  }
+
+  function restoreCanvas() {
+    state.isMinimized = false;
+    state.canvas.style.display = 'block';
+    updateCanvasSize();
+    render();
+
+    state.frame.style.height = `${state.canvas.height * state.zoomFactor + 40}px`;
+    state.frame.style.width = `${state.canvas.width * state.zoomFactor}px`;
+
+    const ctrl = document.getElementById('control-container');
+    if (ctrl) ctrl.style.display = 'block';
+
+    const btns = document.getElementById('button-container');
+    if (btns) btns.style.display = 'flex';
+
+    const restoreBtn = document.getElementById('restore-button');
+    if (restoreBtn) restoreBtn.style.display = 'none';
+
+    const statusCont = document.getElementById('status-container');
+    if (statusCont) statusCont.style.display = state.statusEnabled ? 'block' : 'none';
+
+    if (state.showMinimizeButtons && !state.minimizeBtn) {
+      state.minimizeBtn = document.createElement('button');
+      state.minimizeBtn.textContent = 'X';
+      Object.assign(state.minimizeBtn.style, {
+        position: 'absolute',
+        top: '4px',
+        left: '4px',
+        width: '24px',
+        height: '24px',
+        fontWeight: 'bold',
+        fontSize: '16px',
+        lineHeight: '22px',
+        textAlign: 'center',
+        zIndex: 10002,
+        background: '#f0f0f0',
+        border: '1px solid #444',
+        borderRadius: '4px',
+        cursor: 'pointer',
+        padding: '0',
+        color: 'black'
+      });
+      state.minimizeBtn.onclick = minimizeCanvas;
+      state.frame.appendChild(state.minimizeBtn);
+    }
+  }
+
+  function setupCanvas() {
+    state.frame = document.createElement('div');
+    state.frame.id = 'draggable-frame';
+    state.frame.style.cssText = `
+    position: fixed; top: 20px; left: 20px; background: black;
+    border: 2px solid #555; border-radius: 8px; z-index: 1000;
+  `;
+    state.canvas = document.createElement('canvas');
+    state.canvas.id = 'canvas';
+    state.frame.appendChild(state.canvas);
+    document.body.appendChild(state.frame);
+    state.ctx = state.canvas.getContext('2d');
+
+    const restoreBtn = document.createElement('button');
+    restoreBtn.id = 'restore-button';
+    restoreBtn.textContent = 'Restore nonogram overlay';
+    Object.assign(restoreBtn.style, {
+      position: 'absolute',
+      bottom: '12px',
+      left: '12px',
+      zIndex: '10003',
+      padding: '6px 12px',
+      background: '#00cc44',
+      boxShadow: '0 0 8px #00cc44',
+      color: 'white',
+      fontWeight: 'bold',
+      border: 'none',
+      borderRadius: '6px',
+      cursor: 'pointer',
+      display: 'none'
+    });
+    restoreBtn.onclick = () => restoreCanvas();
+
+    const video = [...document.querySelectorAll('video')].reverse().find(v => v.readyState >= 2);
+    if (video && video.parentElement) {
+      video.parentElement.style.position = 'relative';
+      video.parentElement.appendChild(restoreBtn);
+    } else {
+      document.body.appendChild(restoreBtn);
+    }
+
+    if (state.showMinimizeButtons) {
+      state.minimizeBtn = document.createElement('button');
+      state.minimizeBtn.textContent = 'X';
+      Object.assign(state.minimizeBtn.style, {
+        position: 'absolute',
+        top: '4px',
+        left: '4px',
+        width: '24px',
+        height: '24px',
+        fontWeight: 'bold',
+        fontSize: '16px',
+        lineHeight: '22px',
+        textAlign: 'center',
+        zIndex: 10002,
+        background: '#f0f0f0',
+        border: '1px solid #444',
+        borderRadius: '4px',
+        cursor: 'pointer',
+        padding: '0',
+        color: 'black'
+      });
+      state.minimizeBtn.onclick = minimizeCanvas;
+      state.frame.appendChild(state.minimizeBtn);
+    }
+
+    state.canvas.addEventListener('mousedown', onCanvasMouseDown);
+
+    state.documentMouseMoveHandler = e => {
+      if (state.isDragging) {
+        state.frame.style.left = `${e.clientX - state.dragOffsetX}px`;
+        state.frame.style.top = `${e.clientY - state.dragOffsetY}px`;
+      }
+    };
+    document.addEventListener('mousemove', state.documentMouseMoveHandler);
+
+    state.documentMouseUpHandler = () => {
+      state.isDragging = false;
+      state.isMarking = false;
+      if (state.currentAction && state.currentAction.length) {
+        state.moveHistory.push(state.currentAction);
+      }
+      state.currentAction = null;
+    };
+    document.addEventListener('mouseup', state.documentMouseUpHandler);
+
+    state.canvas.addEventListener('mousemove', onCanvasMouseMove);
+    state.canvas.addEventListener('contextmenu', e => {
+      e.preventDefault();
+    });
+  }
+
+  function updateCanvasSize() {
+    const fixedWidth = Math.round(428 * (0.36 / 0.335));
+    const fixedHeight = 420;
+
+    state.canvas.width = fixedWidth;
+    state.canvas.height = fixedHeight;
+    state.roiCanvas.width = state.canvas.width;
+    state.roiCanvas.height = state.canvas.height;
+    state.canvas.style.width = `${fixedWidth * state.zoomFactor}px`;
+    state.canvas.style.height = `${fixedHeight * state.zoomFactor}px`;
+    state.frame.style.width = `${fixedWidth * state.zoomFactor}px`;
+    state.frame.style.height = `${fixedHeight * state.zoomFactor + 60}px`;
+
+    createGrid();
+    updateROI();
+  }
+
+  function createMainButtons() {
+    if (state.activityBtnMonitorId) {
+      clearInterval(state.activityBtnMonitorId);
+      state.activityBtnMonitorId = null;
+    }
+
+    const container = document.createElement('div');
+    container.id = 'button-container';
+    container.style.cssText = `
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    padding: 6px 8px;
+    z-index: 10001;
+    pointer-events: auto;
+    background: rgba(0,0,0,0.5);
+    border-top: 1px solid #333;
+  `;
+    state.frame.appendChild(container);
+
+    const makeBtn = (label, onClick) => {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      btn.style.cssText = `
+      padding: 4px 8px;
+      background: #fff;
+      border: 1px solid #000;
+      border-radius: 3px;
+      font-size: 13px;
+      color: black;
+      cursor: pointer;
+      transition: background 0.15s ease, opacity 0.15s ease;
+    `;
+      btn.onmouseenter = () => {
+        btn.style.background = '#f0f0f0';
+      };
+      btn.onmouseleave = () => {
+        btn.style.background = '#fff';
+      };
+      btn.onclick = onClick;
+      return btn;
+    };
+
+    state.exportFillBtn = container.appendChild(makeBtn('Export !fill', exportCells));
+    state.exportEmptyBtn = container.appendChild(makeBtn('Export !empty', exportWhiteCells));
+    container.appendChild(makeBtn('Undo', undoLastAction));
+
+    const spacer = document.createElement('div');
+    spacer.style.flex = '1';
+    container.appendChild(spacer);
+
+    container.appendChild(makeBtn('reset export', exportAllCells));
+    container.appendChild(makeBtn('Clean grid', cleanAll));
+    container.appendChild(makeBtn('⚙️ Config', () => {
+      toggleExtraConfigPanel();
+    }));
+
+    const updateActivityBtnStyle = btn => {
+      const mins = minutesSinceRedeem();
+      if (isNaN(mins) || mins < 30) {
+        btn.dataset.alert = '';
+        btn.style.background = '#fff';
+        btn.style.color = 'black';
+        btn.style.border = '1px solid #000';
+      } else if (mins >= 30 && mins <= 45) {
+        btn.dataset.alert = 'warning';
+        btn.style.background = '#ff4444';
+        btn.style.color = 'white';
+        btn.style.border = '1px solid #cc0000';
+      } else {
+        btn.dataset.alert = 'overdue';
+        btn.style.background = '#b22222';
+        btn.style.color = 'white';
+        btn.style.border = '1px solid #800000';
+      }
+    };
+
+    const activityBtn = makeBtn('🎟️ Activity Coupon', async () => {
+      if (activityBtn.disabled) return;
+      try {
+        activityBtn.disabled = true;
+        activityBtn.style.opacity = '0.7';
+        activityBtn.textContent = '⏳ Redeeming...';
+        await redeemAndTrack(() => updateActivityBtnStyle(activityBtn));
+      } catch (e) {
+        console.error('Redeem error:', e);
+      } finally {
+        activityBtn.textContent = '🎟️ Activity Coupon';
+        activityBtn.disabled = false;
+        activityBtn.style.opacity = '1';
+        updateActivityBtnStyle(activityBtn);
+        state.activityBtnMonitorId = setInterval(() => {
+          updateActivityBtnStyle(activityBtn);
+        }, 30_000);
+      }
+    });
+
+    activityBtn.onmouseenter = () => {
+      const alertState = activityBtn.dataset.alert;
+      if (!alertState) activityBtn.style.background = '#f0f0f0';
+      else if (alertState === 'warning') activityBtn.style.background = '#ff2a2a';
+      else if (alertState === 'overdue') activityBtn.style.background = '#8b1a1a';
+    };
+    activityBtn.onmouseleave = () => {
+      updateActivityBtnStyle(activityBtn);
+    };
+
+    container.appendChild(activityBtn);
+    updateActivityBtnStyle(activityBtn);
+    state.activityBtnMonitorId = setInterval(() => {
+      updateActivityBtnStyle(activityBtn);
+    }, 30_000);
+
+    if (state.autosendEnabled) {
+      ensureProgressLoop();
+    }
+  }
+
+  // Bootstraps the userscript, wires the grouped modules together, and handles cleanup.
+
+  configureNonogramGrid({ updateCanvasSize });
+  configureStatusControls({ updateCanvasSize, createGrid, minimizeCanvas });
+
+  function cleanup() {
+    if (state.activityBtnMonitorId) clearInterval(state.activityBtnMonitorId);
+    if (state.progressTimer) clearInterval(state.progressTimer);
+    if (state.sendLoopTimer) clearInterval(state.sendLoopTimer);
+    if (state.roiInterval) clearInterval(state.roiInterval);
+    clearRenderHandle();
+
+    if (state.documentMouseMoveHandler) {
+      document.removeEventListener('mousemove', state.documentMouseMoveHandler);
+    }
+    if (state.documentMouseUpHandler) {
+      document.removeEventListener('mouseup', state.documentMouseUpHandler);
+    }
+  }
+
+  function onLoad() {
+    setupCanvas();
+    initCells();
+    updateCanvasSize();
+    createMainButtons();
+    createConfigPanel();
+    createControlAndStatus();
+    createExtraConfigPanel();
+    if (state.autosendEnabled) {
+      state.nextSendAt = Date.now();
+      ensureProgressLoop();
+    }
+    render();
+    state.roiInterval = setInterval(updateROI, 1000);
+  }
+
+  function bootstrap() {
+    window.addEventListener('beforeunload', cleanup);
+    window.addEventListener('load', onLoad);
+  }
+
+  // Userscript entrypoint that starts the modular app after bundling.
+
+  bootstrap();
 
 })();


### PR DESCRIPTION
## Summary
This refactor splits the original monolithic userscript into a small set of grouped ES modules and adds a Rollup-based build that produces a single installable userscript (twitch-nonogram-canvas.user.js). The goal is a safer, modular codebase while preserving existing runtime behavior and localStorage compatibility. This change is intentionally conservative — grouped modules, not micro-splitting.
## What changed
- Added Rollup build (package.json, rollup.config.mjs).
- Created ES module sources under src/:
  - src/userscript/banner.js, src/userscript/main.js
  - src/app.js
  - src/state.js
  - src/nonogram-grid.js
  - src/overlay-ui.js
  - src/status-controls.js
  - src/twitch-chat.js
  - src/twitch-redeem.js
- Updated README and added .gitignore and .opencode plan file.
- Generated bundle: twitch-nonogram-canvas.user.js (top-level).
- Added cleanup wiring and preserved localStorage keys: nonogramUIConfig, nonogramConfigMap, lastRedeemTimestamp.
## How to build locally
- npm install
- npm run build
- The generated userscript is twitch-nonogram-canvas.user.js at the repo root.
